### PR TITLE
Add optional translation and code-switch prefill columns to supabase.sql

### DIFF
--- a/docs/supabase.sql
+++ b/docs/supabase.sql
@@ -12,7 +12,9 @@
 -- Optional audio proxy col:
 --   audio_proxy_url text
 ALTER TABLE IF EXISTS public.keep
-  ADD COLUMN IF NOT EXISTS audio_proxy_url text;
+  ADD COLUMN IF NOT EXISTS audio_proxy_url text,
+  ADD COLUMN IF NOT EXISTS translation_vtt_url text,
+  ADD COLUMN IF NOT EXISTS code_switch_vtt_url text;
 
 -- Optional separate audio proxies table (if preferred over column on keep)
 CREATE TABLE IF NOT EXISTS public.audio_proxies (


### PR DESCRIPTION
This PR adds two optional prefill columns (`translation_vtt_url` and `code_switch_vtt_url`) to the Supabase `keep` table. These columns will allow Stage 2 to prefill translation and code-switch metadata in the annotation UI. No functional changes are introduced besides updating the SQL migration.