### PR TITLE
Fix Stage 2 routing

### DIFF
--- a/meta-v2/index.html
+++ b/meta-v2/index.html
@@ -164,7 +164,7 @@
       if(new URLSearchParams(location.search).get('links')==='0') return;
       c.innerHTML = `Quick Links: 
         <a href="${base}/">Meta V2</a> · 
-        <a href="${base}/stage2">Stage 2</a> · 
+        <a href="${base}/stage2/index.html">Stage 2</a> ·
         <a href="${base}/api/tasks?stage=2&annotator_id=${encodeURIComponent(id)}&limit=5" target="_blank">Tasks API</a> · 
         <a href="${base}/api/clip?annotator=${encodeURIComponent(id)}" target="_blank">Clip API</a> · 
         <a href="${base}/api/debug?annotator=${encodeURIComponent(id)}" target="_blank">Debug</a>`;

--- a/stage2/index.html
+++ b/stage2/index.html
@@ -156,7 +156,7 @@
       if(new URLSearchParams(location.search).get('links')==='0') return;
       c.innerHTML = `Quick Links: 
         <a href="${base}/">Meta V2</a> · 
-        <a href="${base}/stage2">Stage 2</a> · 
+        <a href="${base}/stage2/index.html">Stage 2</a> ·
         <a href="${base}/api/tasks?stage=2&annotator_id=${encodeURIComponent(id)}&limit=5" target="_blank">Tasks API</a> · 
         <a href="${base}/api/clip?annotator=${encodeURIComponent(id)}" target="_blank">Clip API</a> · 
         <a href="${base}/api/debug?annotator=${encodeURIComponent(id)}" target="_blank">Debug</a>`;

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,9 @@
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "/api/$1.py" },
-    { "src": "/stage2(.*)", "dest": "/stage2/index.html" },
+    { "src": "^/stage2$", "dest": "/stage2/index.html" },
+    { "src": "^/stage2/$", "dest": "/stage2/index.html" },
+    { "src": "^/stage2/(.*)$", "dest": "/stage2/$1" },
     { "src": "/public/(.*)", "dest": "/public/$1" },
     { "src": "/(.*)", "dest": "/meta-v2/index.html" }
   ]


### PR DESCRIPTION
## Summary
- update the quick link footers so Stage 2 explicitly links to the HTML entry point
- adjust the Vercel routing to rewrite /stage2 to index.html without hijacking asset requests

## Testing
- curl -I http://127.0.0.1:8000/stage2/index.html
- curl -I http://127.0.0.1:8000/stage2/app.js
- python - <<'PY'
from fastapi.testclient import TestClient
from api.tasks import app

client = TestClient(app)
resp = client.get('/api/tasks', params={'stage':2, 'annotator_id':'tester', 'limit':2})
print(resp.status_code)
print(resp.json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68dfa985c58c83289d3ffbecb179c6b7