### PR TITLE
Make Stage 2 the default landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ annotate/
     app.js                  # Flow, offline queue, syncing
 ```
 
-`meta-v2` serves as the metadata UI and is exposed at the root path.
+`stage2` serves as the deep annotation UI and is exposed at the root path. `meta-v2` remains available at `/meta-v2` for the legacy metadata experience.
 
 ## vercel.json
 
@@ -46,12 +46,19 @@ annotate/
   "builds": [
     { "src": "api/*.py", "use": "@vercel/python" },
     { "src": "meta-v2/index.html", "use": "@vercel/static" },
+    { "src": "stage2/**/*", "use": "@vercel/static" },
     { "src": "public/**/*", "use": "@vercel/static" }
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "/api/$1.py" },
+    { "src": "^/stage2$", "dest": "/stage2/index.html" },
+    { "src": "^/stage2/$", "dest": "/stage2/index.html" },
+    { "src": "^/stage2/(.*)$", "dest": "/stage2/$1" },
+    { "src": "^/meta-v2$", "dest": "/meta-v2/index.html" },
+    { "src": "^/meta-v2/$", "dest": "/meta-v2/index.html" },
+    { "src": "^/meta-v2/(.*)$", "dest": "/meta-v2/$1" },
     { "src": "/public/(.*)", "dest": "/public/$1" },
-    { "src": "/(.*)", "dest": "/meta-v2/index.html" }
+    { "src": "/(.*)", "dest": "/stage2/index.html" }
   ]
 }
 ```

--- a/meta-v2/index.html
+++ b/meta-v2/index.html
@@ -162,9 +162,9 @@
       function getAnnot(){ try{ const k='dd_annotator_id'; return localStorage.getItem(k)||'anonymous'; }catch{ return 'anonymous'; } }
       const id = getAnnot();
       if(new URLSearchParams(location.search).get('links')==='0') return;
-      c.innerHTML = `Quick Links: 
-        <a href="${base}/">Meta V2</a> · 
-        <a href="${base}/stage2/index.html">Stage 2</a> ·
+      c.innerHTML = `Quick Links:
+        <a href="${base}/meta-v2/index.html">Meta V2</a> ·
+        <a href="${base}/">Stage 2</a> ·
         <a href="${base}/api/tasks?stage=2&annotator_id=${encodeURIComponent(id)}&limit=5" target="_blank">Tasks API</a> · 
         <a href="${base}/api/clip?annotator=${encodeURIComponent(id)}" target="_blank">Clip API</a> · 
         <a href="${base}/api/debug?annotator=${encodeURIComponent(id)}" target="_blank">Debug</a>`;

--- a/stage2/index.html
+++ b/stage2/index.html
@@ -154,9 +154,9 @@
       let id = 'anonymous';
       try { id = localStorage.getItem(annotKey) || 'anonymous'; } catch{}
       if(new URLSearchParams(location.search).get('links')==='0') return;
-      c.innerHTML = `Quick Links: 
-        <a href="${base}/">Meta V2</a> · 
-        <a href="${base}/stage2/index.html">Stage 2</a> ·
+      c.innerHTML = `Quick Links:
+        <a href="${base}/meta-v2/index.html">Meta V2</a> ·
+        <a href="${base}/">Stage 2</a> ·
         <a href="${base}/api/tasks?stage=2&annotator_id=${encodeURIComponent(id)}&limit=5" target="_blank">Tasks API</a> · 
         <a href="${base}/api/clip?annotator=${encodeURIComponent(id)}" target="_blank">Clip API</a> · 
         <a href="${base}/api/debug?annotator=${encodeURIComponent(id)}" target="_blank">Debug</a>`;

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,10 @@
     { "src": "^/stage2$", "dest": "/stage2/index.html" },
     { "src": "^/stage2/$", "dest": "/stage2/index.html" },
     { "src": "^/stage2/(.*)$", "dest": "/stage2/$1" },
+    { "src": "^/meta-v2$", "dest": "/meta-v2/index.html" },
+    { "src": "^/meta-v2/$", "dest": "/meta-v2/index.html" },
+    { "src": "^/meta-v2/(.*)$", "dest": "/meta-v2/$1" },
     { "src": "/public/(.*)", "dest": "/public/$1" },
-    { "src": "/(.*)", "dest": "/meta-v2/index.html" }
+    { "src": "/(.*)", "dest": "/stage2/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- update vercel routing to serve Stage 2 at the root while keeping the legacy Meta V2 UI under /meta-v2
- refresh quick links in both Stage 2 and Meta V2 shells so the default and legacy paths are accurate
- document the new default landing page and routing structure in the README

## Testing
- npx serve -s stage2 -l 5000 & (curl -s http://localhost:5000/ | tr '<' '\n<' | grep 'EchoAtlas Stage 2')

------
https://chatgpt.com/codex/tasks/task_e_68dfad14edf0832880f6d30267db051d