### PR TITLE
Fix Stage 2 timeline overlays and prefill loading

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -62,7 +62,9 @@ video{ width:100%; height:100%; display:block; background:#000 }
 button{ -webkit-tap-highlight-color:transparent }
 /* Timeline */
 .tl{ position:relative; height:32px; background:var(--card); border:1px solid var(--border); border-radius:6px; overflow:hidden }
-.tl-seg{ position:absolute; top:0; bottom:0; background:rgba(43,124,255,0.15); border-left:1px solid var(--accent); border-right:1px solid var(--accent) }
+.tl-seg{ position:absolute; top:0; bottom:0; background:rgba(43,124,255,0.18); border-left:1px solid rgba(43,124,255,0.45); border-right:1px solid rgba(43,124,255,0.45) }
+.tl-seg.tl-cs,.tl-seg.cs,.tl-cs{ background:rgba(43,124,255,0.28); border-color:rgba(43,124,255,0.6); pointer-events:none }
+.tl-seg.tl-evt,.tl-seg.evt,.tl-evt{ background:rgba(230,140,30,0.32); border-color:rgba(230,140,30,0.65); pointer-events:none }
 .tl-handle{ position:absolute; right:-6px; top:0; bottom:0; width:12px; cursor:col-resize; background:rgba(43,124,255,0.3) }
 /* Enhancements for wider screens */
 @media (min-width:600px){

--- a/public/timeline.js
+++ b/public/timeline.js
@@ -27,7 +27,7 @@ const Timeline = (function(){
     function paintOverlay(list, cls){
       (list||[]).forEach(o=>{
         const seg = document.createElement('div');
-        seg.className = `tl-seg ${cls}`;
+        seg.className = `tl-seg ${cls} tl-${cls}`;
         seg.style.left = pct(o.start);
         seg.style.width = `calc(${pct(o.end)} - ${pct(o.start)})`;
         seg.style.background = cls === 'cs' ? 'rgba(43,124,255,0.25)' : 'rgba(230,140,30,0.25)';


### PR DESCRIPTION
## Summary
- fetch Stage 2 translation and code-switch prefills when loading a task, adding fallback cues and an on-screen notice if requests fail
- restyle timeline segments and overlays so transcript cues, code-switch spans, and events are visible during annotation
- tag timeline overlays with dedicated classes to match the new CSS styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfd8348218832893e0a60309decff7