### PR TITLE
Support src downloads in proxy audio handler

### DIFF
--- a/api/proxy_audio.py
+++ b/api/proxy_audio.py
@@ -3,6 +3,7 @@ from fastapi.responses import StreamingResponse, Response
 from urllib.parse import urlparse, quote
 import os
 import requests
+from requests.utils import requote_uri
 
 app = FastAPI()
 
@@ -33,54 +34,44 @@ def allowed_host(url: str) -> bool:
     return host in allowed
 
 
-@app.get("/api/proxy_audio")
-async def proxy_audio(req: Request, src: str | None = None, file: str | None = None):
-    # Build upstream URL
+def build_bunny_url(path: str) -> tuple[str | None, str | None]:
+    base = (BUNNY_KEEP_URL or "").rstrip("/")
+    if not base:
+        return None, None
+
+    from_ext = FROM_EXT if FROM_EXT.startswith(".") else f".{FROM_EXT}"
+    to_ext = TO_EXT if TO_EXT.startswith(".") else f".{TO_EXT}"
+    remote_path = quote(path.lstrip("/"), safe="/:")
+    remote_path_converted = remote_path
+
     fallback_src = None
-    if not src and file:
-        base = (BUNNY_KEEP_URL or "").rstrip("/")
-        from_ext = FROM_EXT if FROM_EXT.startswith(".") else f".{FROM_EXT}"
-        to_ext = TO_EXT if TO_EXT.startswith(".") else f".{TO_EXT}"
-        remote_path = file.lstrip("/")
-        remote_path_converted = remote_path
-        if remote_path_converted.endswith(from_ext):
-            remote_path_converted = remote_path_converted[: -len(from_ext)] + to_ext
-            fallback_src = f"{base}/{remote_path}"
-        src = f"{base}/{remote_path_converted}"
+    if remote_path_converted.endswith(from_ext):
+        remote_path_converted = remote_path_converted[: -len(from_ext)] + to_ext
+        fallback_src = f"{base}/{remote_path}"
 
-    final_src = src
+    return f"{base}/{remote_path_converted}", fallback_src
 
-    if fallback_src and src:
-        try:
-            head_resp = requests.head(src, timeout=10)
-            if 400 <= head_resp.status_code < 500:
-                final_src = fallback_src
-        except Exception:
-            pass
-    elif not src:
-        final_src = None
 
-    if not final_src:
-        return Response(status_code=400, content=b"missing src or file")
-
-    if not allowed_host(final_src):
-        return Response(status_code=403, content=b"host not allowed")
-
-    # Forward Range header if present
+def build_streaming_response(req: Request, url: str) -> Response:
     headers = {}
     if "range" in req.headers:
         headers["Range"] = req.headers["range"]
 
     try:
-        upstream = requests.get(final_src, headers=headers, stream=True, timeout=30)
+        upstream = requests.get(url, headers=headers, stream=True, timeout=30)
     except Exception:
         return Response(status_code=502, content=b"upstream error")
 
     status = upstream.status_code
-    # Default content-type for opus
-    content_type = upstream.headers.get("content-type") or (
-        "audio/ogg" if final_src.lower().endswith(".opus") else "application/octet-stream"
-    )
+
+    default_type = "application/octet-stream"
+    lower_url = url.lower()
+    if lower_url.endswith(".opus"):
+        default_type = "audio/ogg"
+    elif lower_url.endswith(".vtt"):
+        default_type = "text/vtt"
+
+    content_type = upstream.headers.get("content-type") or default_type
     content_length = upstream.headers.get("content-length")
     content_range = upstream.headers.get("content-range")
 
@@ -97,3 +88,33 @@ async def proxy_audio(req: Request, src: str | None = None, file: str | None = N
     resp.headers["Accept-Ranges"] = "bytes"
     resp.headers["Cache-Control"] = "public, max-age=60"
     return resp
+
+
+@app.get("/api/proxy_audio")
+async def proxy_audio(req: Request, src: str | None = None, file: str | None = None):
+    final_src = None
+    fallback_src = None
+
+    if file and not src:
+        final_src, fallback_src = build_bunny_url(file)
+    elif src:
+        parsed = urlparse(src)
+        if not parsed.scheme or not parsed.netloc:
+            return Response(status_code=400, content=b"src must be absolute")
+        final_src = requote_uri(src)
+
+    if not final_src:
+        return Response(status_code=400, content=b"missing src or file")
+
+    if fallback_src and final_src:
+        try:
+            head_resp = requests.head(final_src, timeout=10)
+            if 400 <= head_resp.status_code < 500:
+                final_src = fallback_src
+        except Exception:
+            pass
+
+    if not allowed_host(final_src):
+        return Response(status_code=403, content=b"host not allowed")
+
+    return build_streaming_response(req, final_src)


### PR DESCRIPTION
## Summary
- allow the `/api/proxy_audio` handler to accept absolute `src` URLs and proxy them
- reuse the streaming response logic to support ranged downloads and VTT content types
- keep bunny-hosted fallback logic while normalising paths and URLs

## Testing
- python -m compileall api/proxy_audio.py

------
https://chatgpt.com/codex/tasks/task_e_68e03635783883289623924c97b7b866