### PR TITLE
Allow Bunny CDN host for proxy audio requests

### DIFF
--- a/api/proxy_audio.py
+++ b/api/proxy_audio.py
@@ -18,6 +18,8 @@ def allowed_host(url: str) -> bool:
         host = (urlparse(url).hostname or "").lower()
     except Exception:
         return False
+    if host == "dialect-data-videos.b-cdn.net":
+        return True
     allowed = set([h.strip().lower() for h in (ALLOWED_PROXY_HOSTS or "").split(",") if h.strip()])
     bunny_host = None
     if BUNNY_KEEP_URL:


### PR DESCRIPTION
## Summary
- allow the proxy audio endpoint to accept URLs from dialect-data-videos.b-cdn.net in addition to other allowed hosts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03fe855e88328b339d4fe74bfb267