### PR TITLE
Allow proxy src requests from any host

### DIFF
--- a/api/proxy_audio.py
+++ b/api/proxy_audio.py
@@ -13,7 +13,9 @@ FROM_EXT = os.environ.get("AUDIO_PROXY_FROM_EXT", ".mp4")
 TO_EXT = os.environ.get("AUDIO_PROXY_EXT", ".opus")
 
 
-def allowed_host(url: str) -> bool:
+def allowed_host(url: str, *, from_src: bool = False) -> bool:
+    if from_src:
+        return True
     try:
         host = (urlparse(url).hostname or "").lower()
     except Exception:
@@ -116,7 +118,9 @@ async def proxy_audio(req: Request, src: str | None = None, file: str | None = N
         except Exception:
             pass
 
-    if not allowed_host(final_src):
+    from_src = bool(src)
+
+    if not allowed_host(final_src, from_src=from_src):
         return Response(status_code=403, content=b"host not allowed")
 
     return build_streaming_response(req, final_src)


### PR DESCRIPTION
## Summary
- allow `src`-based proxy requests to bypass host allowlist checks
- preserve existing host restrictions for Bunny file-based fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04420f2b483288bb7a1cc697c950b