### PR TITLE
Fix Stage 2 navigation to emotion safety screen

### DIFF
--- a/stage2/app.js
+++ b/stage2/app.js
@@ -1210,8 +1210,8 @@ function bindUI(){
     }
     if(speakerError){ speakerError.classList.add('hide'); speakerError.textContent = ''; }
     runValidationAndDisplay('screen_codeswitch');
-    show('screen_emotion');
-    runValidationAndDisplay('screen_emotion');
+    show('screen_emotionSafety');
+    runValidationAndDisplay('screen_emotionSafety');
   });
 
   const timelineEl = qs('timeline');


### PR DESCRIPTION
## Summary
- update Stage 2 navigation to show the combined emotion/safety screen after code-switching

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e405fb7e688328b6ea817745ed98f2