### PR TITLE
Implement full QA scoring logic and gold-clip injection

### DIFF
--- a/stage2/app.js
+++ b/stage2/app.js
@@ -1089,6 +1089,13 @@ async function enqueueAndSync(lintReport){
   if(emotionVtt){ files.emotion_vtt = emotionVtt; }
   if(eventsVtt){ files.events_vtt = eventsVtt; }
 
+  const timeSpentSec = Math.max(0, Math.round((Date.now() - (EAQ.state.startedAt||Date.now()))/1000));
+  const lintSummary = Object.assign({}, lint, {
+    errors: Array.isArray(lint.errors) ? lint.errors.slice() : [],
+    warnings: Array.isArray(lint.warnings) ? lint.warnings.slice() : [],
+    severity_max: (Array.isArray(lint.errors) && lint.errors.length) ? 'error' : ((Array.isArray(lint.warnings) && lint.warnings.length) ? 'warning' : 'ok')
+  });
+
   const payload = {
     asset_id: it.asset_id,
     files,
@@ -1104,15 +1111,73 @@ async function enqueueAndSync(lintReport){
       annotator_id: EAQ.state.annotator,
       second_annotator_id: null,
       adjudicator_id: null,
-      gold_check: 'pass',
-      time_spent_sec: Math.max(0, Math.round((Date.now() - (EAQ.state.startedAt||Date.now()))/1000)),
-      lint
+      gold_target: !!it.gold_target,
+      gold_check: !!it.gold_target ? 'pending' : 'not_applicable',
+      time_spent_sec: timeSpentSec,
+      clip_id: it.asset_id || it.id || it.clip_id || it.clipId || null,
+      lint: lintSummary
     },
-    lint,
+    lint: lintSummary,
     client_meta: { device: navigator.userAgent }
   };
 
-  try{ await EAIDB.saveLintReport(it.asset_id, lint); }
+  let qaResult = null;
+  if(it.gold_target && window.QAMetrics && typeof window.QAMetrics.computeQAResult === 'function'){
+    try{
+      const predicted = {
+        codeSwitchSpans: csSnapshot,
+        diarization: EAQ.state.diarSegments || [],
+        transcript: EAQ.state.transcriptVTT,
+        translation: EAQ.state.translationVTT
+      };
+      const goldSource = it.gold || it.gold_annotations || it.qa_gold || it.reference || it.prefill || {};
+      const thresholds = it.qa_thresholds || it.qaThresholds || null;
+      qaResult = window.QAMetrics.computeQAResult(predicted, goldSource, { thresholds });
+      if(qaResult){
+        payload.qa.gold_check = qaResult.pass ? 'pass' : 'fail';
+        payload.qa.codeswitch_f1 = qaResult.codeswitch && Number.isFinite(qaResult.codeswitch.f1) ? qaResult.codeswitch.f1 : null;
+        payload.qa.codeswitch_precision = qaResult.codeswitch && Number.isFinite(qaResult.codeswitch.precision) ? qaResult.codeswitch.precision : null;
+        payload.qa.codeswitch_recall = qaResult.codeswitch && Number.isFinite(qaResult.codeswitch.recall) ? qaResult.codeswitch.recall : null;
+        payload.qa.diarization_mae = qaResult.diarization && Number.isFinite(qaResult.diarization.mae) ? qaResult.diarization.mae : null;
+        payload.qa.cue_avg_length_sec = qaResult.cues && Number.isFinite(qaResult.cues.avgCueLengthSec) ? qaResult.cues.avgCueLengthSec : null;
+        payload.qa.cue_diff_sec = qaResult.cues && Number.isFinite(qaResult.cues.targetDiffSec) ? qaResult.cues.targetDiffSec : null;
+        payload.qa.translation_completeness = qaResult.translation && Number.isFinite(qaResult.translation.completeness) ? qaResult.translation.completeness : null;
+        payload.qa.translation_correctness = qaResult.translation && Number.isFinite(qaResult.translation.correctness) ? qaResult.translation.correctness : null;
+        payload.qa.translation_char_ratio = qaResult.cues && Number.isFinite(qaResult.cues.translationCompleteness) ? qaResult.cues.translationCompleteness : null;
+        payload.qa.scores = {
+          accuracy: qaResult.accuracyScore,
+          consistency: qaResult.consistencyScore,
+          cue: qaResult.cueScore,
+          translation: qaResult.translationScore,
+          overall: qaResult.overallScore
+        };
+        payload.qa.metrics = qaResult;
+      }
+    }catch(err){
+      console.warn('QA computation failed', err);
+      payload.qa.gold_check = 'error';
+    }
+  }
+
+  const clipId = it.asset_id || it.id || it.clip_id || it.clipId;
+  if(window.QAMetrics && typeof window.QAMetrics.recordResult === 'function'){
+    try{
+      window.QAMetrics.recordResult(clipId, {
+        qa: payload.qa,
+        metrics: qaResult,
+        clip: {
+          clipId,
+          title: it.title || it.clip_title || it.display_title || null,
+          language: it.language || null,
+          gold_target: !!it.gold_target
+        }
+      });
+    }catch(err){
+      console.warn('Failed to record QA result', err);
+    }
+  }
+
+  try{ await EAIDB.saveLintReport(it.asset_id, lintSummary); }
   catch{}
 
   await EAIDB.enqueue(payload);
@@ -1268,7 +1333,6 @@ function bindUI(){
       try{
         const qaReport = window.QAMetrics.generateReport({
           manifest: EAQ.state.manifest,
-          annotations: { lint },
           annotator: EAQ.state.annotator
         });
         localStorage.setItem('qa_report', JSON.stringify(qaReport));

--- a/stage2/qa-dashboard.html
+++ b/stage2/qa-dashboard.html
@@ -30,14 +30,30 @@
     </nav>
     <section class="screen" aria-labelledby="qaDashboardTitle">
       <h2 id="qaDashboardTitle">QA Dashboard</h2>
-      <p class="notice qa-dashboard__intro">QA metrics will appear here once they're available. This placeholder screen reserves space for charts and summaries.</p>
-      <div class="qa-dashboard__empty" id="qaReportEmpty" role="status">No QA metrics to display yet.</div>
+      <p class="notice qa-dashboard__intro">Review your gold-clip QA results and detailed per-metric scores. Metrics update automatically after each submission.</p>
+      <div class="qa-dashboard__empty" id="qaReportEmpty" role="status">No QA metrics to display yet. Complete a gold clip to populate this dashboard.</div>
       <table class="qa-report-table hide" id="qaSummaryTable">
         <caption>Latest QA Summary</caption>
         <thead>
           <tr>
             <th scope="col">Metric</th>
             <th scope="col">Value</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <table class="qa-report-table hide" id="qaAnnotatorsTable">
+        <caption>Per-Annotator Averages</caption>
+        <thead>
+          <tr>
+            <th scope="col">Annotator</th>
+            <th scope="col">Clips</th>
+            <th scope="col">Pass Rate</th>
+            <th scope="col">Avg F1</th>
+            <th scope="col">Diar MAE (s)</th>
+            <th scope="col">Cue Δ (s)</th>
+            <th scope="col">Translation %</th>
+            <th scope="col">Char Coverage %</th>
           </tr>
         </thead>
         <tbody></tbody>
@@ -49,7 +65,12 @@
             <th scope="col">Clip</th>
             <th scope="col">Language</th>
             <th scope="col">QA Status</th>
-            <th scope="col">Comment</th>
+            <th scope="col">Code-Switch F1</th>
+            <th scope="col">Diar MAE (s)</th>
+            <th scope="col">Cue Δ (s)</th>
+            <th scope="col">Translation %</th>
+            <th scope="col">Char Coverage %</th>
+            <th scope="col">Time Spent</th>
           </tr>
         </thead>
         <tbody id="qaReportClips"></tbody>
@@ -84,6 +105,8 @@
       const emptyState = document.getElementById('qaReportEmpty');
       const summaryTable = document.getElementById('qaSummaryTable');
       const summaryBody = summaryTable ? summaryTable.querySelector('tbody') : null;
+      const annotatorsTable = document.getElementById('qaAnnotatorsTable');
+      const annotatorsBody = annotatorsTable ? annotatorsTable.querySelector('tbody') : null;
       const clipsTable = document.getElementById('qaClipsTable');
       const clipsBody = document.getElementById('qaReportClips');
 
@@ -105,20 +128,30 @@
       }
 
       if(emptyState){ emptyState.classList.add('hide'); }
+      const formatPercent = (value, digits = 1)=>{
+        if(typeof value !== 'number' || !Number.isFinite(value)) return 'N/A';
+        return `${(value * 100).toFixed(digits)}%`;
+      };
+      const formatSeconds = (value, digits = 2)=>{
+        if(typeof value !== 'number' || !Number.isFinite(value)) return 'N/A';
+        return `${value.toFixed(digits)} s`;
+      };
+
       if(summaryTable && summaryBody){
-        const formatScore = (value)=>{
-          if(typeof value === 'number'){ return `${Math.round(value * 100)}%`; }
-          if(typeof value === 'string' && value.trim() !== ''){ return value; }
-          return 'N/A';
-        };
+        const summary = report.summary || {};
         const rows = [
           ['Generated At', report.generatedAt ? new Date(report.generatedAt).toLocaleString() : 'Unknown'],
           ['Annotator', report.annotator || 'anonymous'],
-          ['Total Gold Clips', report.summary && report.summary.totalGoldClips != null ? report.summary.totalGoldClips : '0'],
-          ['Reviewed Clips', report.summary && report.summary.reviewedClips != null ? report.summary.reviewedClips : '0'],
-          ['Accuracy Score', formatScore(report.summary && report.summary.accuracyScore)],
-          ['Consistency Score', formatScore(report.summary && report.summary.consistencyScore)],
-          ['Notes', report.summary && report.summary.notes ? report.summary.notes : 'No notes available']
+          ['Total Gold Clips', summary.totalGoldClips != null ? summary.totalGoldClips : '0'],
+          ['Reviewed Clips', summary.reviewedClips != null ? summary.reviewedClips : '0'],
+          ['Pass Rate', formatPercent(summary.passRate || 0)],
+          ['Average Code-Switch F1', formatPercent(summary.averageCodeSwitchF1 || 0)],
+          ['Average Diarization MAE', formatSeconds(summary.averageDiarizationMAE || 0)],
+          ['Average Cue Length', formatSeconds(summary.averageCueLengthSec || 0)],
+          ['Average Cue Δ', formatSeconds(summary.averageCueDiffSec || 0)],
+          ['Translation Completeness', formatPercent(summary.translationCompletenessAvg || 0)],
+          ['Translation Char Coverage', formatPercent(summary.translationCharRatioAvg || 0)],
+          ['Average Time Spent', formatSeconds(summary.averageTimeSpentSec || 0)]
         ];
         summaryBody.innerHTML = '';
         rows.forEach(([label, value])=>{
@@ -135,6 +168,42 @@
         summaryTable.classList.remove('hide');
       }
 
+      if(annotatorsTable && annotatorsBody){
+        annotatorsBody.innerHTML = '';
+        const perAnnotator = Array.isArray(report.perAnnotator) ? report.perAnnotator : [];
+        if(perAnnotator.length){
+          perAnnotator.forEach((row)=>{
+            const tr = document.createElement('tr');
+            const cells = [
+              row.annotator_id || 'anonymous',
+              row.clips != null ? row.clips : '0',
+              formatPercent(row.passRate || 0),
+              formatPercent(row.averageCodeSwitchF1 || 0),
+              formatSeconds(row.averageDiarizationMAE || 0),
+              formatSeconds(row.averageCueDiffSec || 0),
+              formatPercent(row.translationCompletenessAvg || 0),
+              formatPercent(row.translationCharRatioAvg || 0)
+            ];
+            cells.forEach((value, idx)=>{
+              const cell = document.createElement('td');
+              if(idx === 0){
+                const th = document.createElement('th');
+                th.scope = 'row';
+                th.textContent = value;
+                tr.appendChild(th);
+              } else {
+                cell.textContent = value;
+                tr.appendChild(cell);
+              }
+            });
+            annotatorsBody.appendChild(tr);
+          });
+          annotatorsTable.classList.remove('hide');
+        } else {
+          annotatorsTable.classList.add('hide');
+        }
+      }
+
       if(clipsTable && clipsBody){
         clipsBody.innerHTML = '';
         if(Array.isArray(report.clips) && report.clips.length){
@@ -146,13 +215,29 @@
             const langCell = document.createElement('td');
             langCell.textContent = clip.language || 'unknown';
             const statusCell = document.createElement('td');
-            statusCell.textContent = clip.qaStatus || 'Pending';
-            const commentCell = document.createElement('td');
-            commentCell.textContent = clip.comment || '—';
+            statusCell.textContent = (clip.qaStatus || 'pending').toString().toUpperCase();
+            const codeSwitchCell = document.createElement('td');
+            const diarCell = document.createElement('td');
+            const cueCell = document.createElement('td');
+            const translationCell = document.createElement('td');
+            const translationCharCell = document.createElement('td');
+            const timeCell = document.createElement('td');
+            const metrics = clip.metrics || {};
+            codeSwitchCell.textContent = typeof metrics.codeswitch_f1 === 'number' ? formatPercent(metrics.codeswitch_f1, 1) : 'N/A';
+            diarCell.textContent = typeof metrics.diarization_mae === 'number' ? formatSeconds(metrics.diarization_mae, 2) : 'N/A';
+            cueCell.textContent = typeof metrics.cue_diff_sec === 'number' ? formatSeconds(metrics.cue_diff_sec, 2) : 'N/A';
+            translationCell.textContent = typeof metrics.translation_completeness === 'number' ? formatPercent(metrics.translation_completeness, 1) : 'N/A';
+            translationCharCell.textContent = typeof metrics.translation_char_ratio === 'number' ? formatPercent(metrics.translation_char_ratio, 1) : 'N/A';
+            timeCell.textContent = typeof clip.timeSpentSec === 'number' ? formatSeconds(clip.timeSpentSec, 0) : 'N/A';
             tr.appendChild(clipCell);
             tr.appendChild(langCell);
             tr.appendChild(statusCell);
-            tr.appendChild(commentCell);
+            tr.appendChild(codeSwitchCell);
+            tr.appendChild(diarCell);
+            tr.appendChild(cueCell);
+            tr.appendChild(translationCell);
+            tr.appendChild(translationCharCell);
+            tr.appendChild(timeCell);
             clipsBody.appendChild(tr);
           });
           clipsTable.classList.remove('hide');

--- a/stage2/qa_metrics.js
+++ b/stage2/qa_metrics.js
@@ -1,55 +1,578 @@
 (function(global){
-  function selectGoldClips(manifest){
-    if(!manifest || !Array.isArray(manifest.items)){
-      return [];
-    }
-    return manifest.items.slice(0, 3).map((item, index)=>({
-      clipId: item.id || `clip-${index + 1}`,
-      title: item.title || item.clip_title || `Clip ${index + 1}`,
-      language: item.language || 'unknown'
-    }));
+  const STORAGE_KEY = 'qa_history_v1';
+  const REPORT_KEY = 'qa_report';
+  const DEFAULT_TOLERANCE_MS = 300;
+  const DEFAULT_BOUNDARY_PENALTY = 5; // seconds
+  const TARGET_CUE_MEAN_SEC = 2.5;
+  const TARGET_CUE_RANGE = [2, 3];
+
+  function clamp01(v){
+    if(!Number.isFinite(v)) return 0;
+    return Math.min(1, Math.max(0, v));
   }
 
-  function computeMetrics(clips, context){
-    const totalGoldClips = Array.isArray(clips) ? clips.length : 0;
+  function toNumber(value){
+    if(value == null) return NaN;
+    const num = typeof value === 'string' ? parseFloat(value) : Number(value);
+    return Number.isFinite(num) ? num : NaN;
+  }
+
+  function toMs(value){
+    const num = toNumber(value);
+    if(!Number.isFinite(num)) return NaN;
+    return num;
+  }
+
+  function normalizeSpans(spans){
+    if(!Array.isArray(spans)) return [];
+    return spans
+      .map((span)=>{
+        if(!span) return null;
+        const start = toMs(span.start);
+        const end = toMs(span.end);
+        if(!Number.isFinite(start) || !Number.isFinite(end)) return null;
+        if(end <= start) return null;
+        return { start, end, lang: span.lang || span.language || null };
+      })
+      .filter(Boolean)
+      .sort((a, b)=> a.start - b.start || a.end - b.end);
+  }
+
+  function spansOverlap(pred, gold, tolerance){
+    if(!pred || !gold) return false;
+    const tol = Number.isFinite(tolerance) ? Math.max(0, tolerance) : DEFAULT_TOLERANCE_MS;
+    const overlaps = !(pred.end < gold.start || pred.start > gold.end);
+    if(overlaps) return true;
+    if(pred.start <= gold.end + tol && pred.end >= gold.start - tol) return true;
+    return false;
+  }
+
+  function scoreCodeSwitchF1(predSpans, goldSpans, toleranceMs){
+    const preds = normalizeSpans(predSpans);
+    const golds = normalizeSpans(goldSpans);
+    const tol = Number.isFinite(toleranceMs) ? toleranceMs : DEFAULT_TOLERANCE_MS;
+    if(!golds.length && !preds.length){
+      return { precision: 1, recall: 1, f1: 1, matches: [] };
+    }
+    const matches = [];
+    const usedPred = new Set();
+    golds.forEach((gold)=>{
+      let best = null;
+      let bestIdx = -1;
+      let bestScore = Infinity;
+      preds.forEach((pred, idx)=>{
+        if(usedPred.has(idx)) return;
+        if(!spansOverlap(pred, gold, tol)) return;
+        const score = Math.abs(pred.start - gold.start) + Math.abs(pred.end - gold.end);
+        if(score < bestScore){
+          bestScore = score;
+          best = pred;
+          bestIdx = idx;
+        }
+      });
+      if(best && bestIdx >= 0){
+        usedPred.add(bestIdx);
+        matches.push({ gold, pred: best, deltaStart: best.start - gold.start, deltaEnd: best.end - gold.end });
+      }
+    });
+    const tp = matches.length;
+    const fp = Math.max(0, preds.length - tp);
+    const fn = Math.max(0, golds.length - tp);
+    const precision = tp + fp === 0 ? (tp === 0 ? 1 : 0) : tp / (tp + fp);
+    const recall = tp + fn === 0 ? (tp === 0 ? 1 : 0) : tp / (tp + fn);
+    const f1 = (precision + recall) === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+    return { precision, recall, f1, tp, fp, fn, matches, preds, golds };
+  }
+
+  function parseRttm(input){
+    if(!input) return [];
+    if(Array.isArray(input)){
+      return input
+        .map((seg)=>{
+          if(!seg) return null;
+          const start = toNumber(seg.start);
+          const end = seg.end != null ? toNumber(seg.end) : (seg.duration != null ? toNumber(seg.duration) + toNumber(seg.start) : NaN);
+          const speaker = seg.speaker || seg.spk || seg.label || seg.speaker_id || null;
+          if(!Number.isFinite(start)) return null;
+          let segmentEnd = end;
+          if(!Number.isFinite(segmentEnd) && Number.isFinite(seg.duration)){
+            segmentEnd = start + toNumber(seg.duration);
+          }
+          if(!Number.isFinite(segmentEnd) || segmentEnd <= start) return null;
+          return { start, end: segmentEnd, speaker };
+        })
+        .filter(Boolean)
+        .sort((a,b)=> a.start - b.start || a.end - b.end);
+    }
+    const text = String(input || '').trim();
+    if(!text) return [];
+    const segments = [];
+    text.split(/\r?\n+/).forEach((line)=>{
+      const trimmed = line.trim();
+      if(!trimmed || trimmed.startsWith('#')) return;
+      const parts = trimmed.split(/\s+/);
+      if(parts.length < 5) return;
+      const type = parts[0].toUpperCase();
+      if(type !== 'SPEAKER') return;
+      const start = toNumber(parts[3]);
+      const dur = toNumber(parts[4]);
+      const speaker = parts[7] || null;
+      if(!Number.isFinite(start) || !Number.isFinite(dur) || dur <= 0) return;
+      segments.push({ start, end: start + dur, speaker });
+    });
+    return segments.sort((a,b)=> a.start - b.start || a.end - b.end);
+  }
+
+  function boundariesFromSegments(segments){
+    const normalized = parseRttm(segments);
+    if(!normalized.length) return [];
+    const boundaries = [];
+    normalized.sort((a,b)=> a.start - b.start || a.end - b.end);
+    for(let i=1; i<normalized.length; i+=1){
+      const boundary = toNumber(normalized[i].start);
+      if(Number.isFinite(boundary)){
+        boundaries.push(boundary);
+      }
+    }
+    return boundaries.sort((a,b)=> a - b);
+  }
+
+  function scoreDiarizationMAE(predRTTM, goldRTTM, options){
+    const penalty = options && Number.isFinite(options.penalty) ? options.penalty : DEFAULT_BOUNDARY_PENALTY;
+    const predBoundaries = boundariesFromSegments(predRTTM);
+    const goldBoundaries = boundariesFromSegments(goldRTTM);
+    if(!goldBoundaries.length && !predBoundaries.length){
+      return { mae: 0, matches: [], predBoundaries, goldBoundaries };
+    }
+    if(!goldBoundaries.length){
+      const mae = predBoundaries.length ? penalty : 0;
+      return { mae, matches: [], predBoundaries, goldBoundaries };
+    }
+    const usedPred = new Set();
+    const deltas = [];
+    goldBoundaries.forEach((gold)=>{
+      let bestIdx = -1;
+      let bestDiff = Infinity;
+      predBoundaries.forEach((pred, idx)=>{
+        if(usedPred.has(idx)) return;
+        const diff = Math.abs(pred - gold);
+        if(diff < bestDiff){
+          bestDiff = diff;
+          bestIdx = idx;
+        }
+      });
+      if(bestIdx >= 0){
+        usedPred.add(bestIdx);
+        deltas.push(bestDiff);
+      } else {
+        deltas.push(penalty);
+      }
+    });
+    predBoundaries.forEach((pred, idx)=>{
+      if(usedPred.has(idx)) return;
+      deltas.push(penalty);
+    });
+    const mae = deltas.length ? (deltas.reduce((sum, d)=> sum + Math.abs(d), 0) / deltas.length) : 0;
+    return { mae, matches: deltas, predBoundaries, goldBoundaries };
+  }
+
+  function parseTimestamp(ts){
+    if(typeof ts !== 'string') return NaN;
+    const value = ts.trim();
+    if(!value) return NaN;
+    const cleaned = value.replace(',', '.');
+    const parts = cleaned.split(':');
+    if(parts.length === 1){
+      return parseFloat(parts[0]) || 0;
+    }
+    let seconds = 0;
+    let multiplier = 1;
+    for(let i = parts.length - 1; i >= 0; i -= 1){
+      const num = parseFloat(parts[i]);
+      if(!Number.isFinite(num)) return NaN;
+      seconds += num * multiplier;
+      multiplier *= 60;
+    }
+    return seconds;
+  }
+
+  function parseVttCues(input){
+    if(!input) return [];
+    if(Array.isArray(input)){
+      return input
+        .map((cue)=>{
+          if(!cue) return null;
+          const start = toNumber(cue.start != null ? cue.start : cue.startTime || cue.start_seconds);
+          const end = toNumber(cue.end != null ? cue.end : cue.endTime || cue.end_seconds);
+          const text = cue.text != null ? String(cue.text) : '';
+          if(!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+          return { start, end, text };
+        })
+        .filter(Boolean);
+    }
+    const text = String(input || '');
+    if(!text.trim()) return [];
+    const cues = [];
+    const blocks = text.replace(/\r/g, '').split(/\n\n+/);
+    blocks.forEach((block)=>{
+      const lines = block.trim().split(/\n+/).filter(Boolean);
+      if(!lines.length) return;
+      let timeIdx = lines.findIndex((line)=> line.includes('-->'));
+      if(timeIdx === -1){
+        timeIdx = 0;
+      }
+      const timeLine = lines[timeIdx];
+      const timeParts = timeLine.split('-->');
+      if(timeParts.length < 2) return;
+      const start = parseTimestamp(timeParts[0]);
+      const end = parseTimestamp(timeParts[1]);
+      if(!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return;
+      const textLines = lines.slice(timeIdx + 1);
+      const cueText = textLines.join('\n');
+      cues.push({ start, end, text: cueText });
+    });
+    return cues;
+  }
+
+  function computeDurations(cues){
+    if(!Array.isArray(cues) || !cues.length) return [];
+    return cues.map((cue)=> Math.max(0, toNumber(cue.end) - toNumber(cue.start))).filter((dur)=> Number.isFinite(dur) && dur > 0);
+  }
+
+  function average(values){
+    const list = values.filter((v)=> Number.isFinite(v));
+    if(!list.length) return 0;
+    const sum = list.reduce((acc, v)=> acc + v, 0);
+    return sum / list.length;
+  }
+
+  function stddev(values){
+    const list = values.filter((v)=> Number.isFinite(v));
+    if(list.length <= 1) return 0;
+    const mean = average(list);
+    const variance = list.reduce((acc, v)=> acc + Math.pow(v - mean, 2), 0) / list.length;
+    return Math.sqrt(variance);
+  }
+
+  function countCharacters(cues){
+    if(!Array.isArray(cues)) return 0;
+    return cues.reduce((acc, cue)=>{
+      const text = cue && cue.text ? String(cue.text) : '';
+      return acc + text.replace(/\s+/g, '').length;
+    }, 0);
+  }
+
+  function countTokens(cues){
+    if(!Array.isArray(cues)) return 0;
+    return cues.reduce((acc, cue)=>{
+      const text = cue && cue.text ? String(cue.text).trim() : '';
+      if(!text) return acc;
+      return acc + text.split(/\s+/).length;
+    }, 0);
+  }
+
+  function scoreCueStats(transcriptVTT, translationVTT){
+    const transcriptCues = parseVttCues(transcriptVTT);
+    const translationCues = parseVttCues(translationVTT);
+    const durations = computeDurations(transcriptCues);
+    const avgLength = average(durations);
+    const std = stddev(durations);
+    const diff = avgLength - TARGET_CUE_MEAN_SEC;
+    const withinRange = avgLength >= TARGET_CUE_RANGE[0] && avgLength <= TARGET_CUE_RANGE[1];
+    const sourceChars = countCharacters(transcriptCues);
+    const translatedChars = countCharacters(translationCues);
+    const completeness = sourceChars > 0 ? translatedChars / sourceChars : (translatedChars > 0 ? 1 : 0);
     return {
-      totalGoldClips,
-      reviewedClips: Math.min(totalGoldClips, 2),
-      accuracyScore: 0.87,
-      consistencyScore: 0.91,
-      notes: 'Placeholder metrics generated for QA preview.',
-      context: context || {}
+      avgCueLengthSec: avgLength,
+      stdCueLengthSec: std,
+      targetDiffSec: diff,
+      withinTargetRange: withinRange,
+      sourceCharCount: sourceChars,
+      translationCharCount: translatedChars,
+      translationCompleteness: completeness
     };
+  }
+
+  function scoreTranslationStats(translationVTT, referenceVTT){
+    const translationCues = parseVttCues(translationVTT);
+    const referenceCues = parseVttCues(referenceVTT);
+    const translationTokens = countTokens(translationCues);
+    const referenceTokens = countTokens(referenceCues);
+    const completeness = referenceTokens > 0 ? translationTokens / referenceTokens : (translationTokens > 0 ? 1 : 0);
+    const correctness = referenceTokens > 0 ? 1 - Math.min(1, Math.abs(translationTokens - referenceTokens) / Math.max(referenceTokens, 1)) : 1;
+    return {
+      completeness,
+      correctness,
+      translationTokens,
+      referenceTokens,
+      cueCount: translationCues.length
+    };
+  }
+
+  function normalizeThresholds(options){
+    const defaults = {
+      codeswitchF1: 0.75,
+      codeswitchToleranceMs: DEFAULT_TOLERANCE_MS,
+      diarizationMAE: 0.5,
+      diarizationPenaltySec: DEFAULT_BOUNDARY_PENALTY,
+      cueTargetDiff: 0.75,
+      translationCompleteness: 0.85,
+      translationCorrectness: 0.75
+    };
+    return Object.assign({}, defaults, options || {});
+  }
+
+  function computeScoreFromDiff(diff, tolerance){
+    if(!Number.isFinite(diff)) return 0;
+    const limit = Math.max(tolerance || 1, 0.001);
+    const normalized = Math.max(0, 1 - Math.min(1, Math.abs(diff) / limit));
+    return normalized;
+  }
+
+  function computeQAResult(pred, gold, options){
+    const thresholds = normalizeThresholds(options && options.thresholds);
+    const predicted = pred || {};
+    const goldData = gold || {};
+
+    const predSpans = predicted.codeSwitchSpans || predicted.code_switch_spans || predicted.spans || [];
+    const goldSpans = goldData.codeSwitchSpans || goldData.code_switch_spans || goldData.spans || [];
+    const codeswitch = scoreCodeSwitchF1(predSpans, goldSpans, thresholds.codeswitchToleranceMs);
+
+    const predDiar = predicted.diarization || predicted.diarization_rttm || predicted.diarSegments || predicted.rttm || [];
+    const goldDiar = goldData.diarization || goldData.diarization_rttm || goldData.rttm || [];
+    const diarization = scoreDiarizationMAE(predDiar, goldDiar, { penalty: thresholds.diarizationPenaltySec });
+
+    const transcriptVTT = predicted.transcript || predicted.transcript_vtt || predicted.transcriptVTT || '';
+    const translationVTT = predicted.translation || predicted.translation_vtt || predicted.translationVTT || '';
+    const goldTranscript = goldData.transcript || goldData.transcript_vtt || goldData.transcriptVTT || goldData.source_transcript_vtt || '';
+    const goldTranslation = goldData.translation || goldData.translation_vtt || goldData.translationVTT || '';
+
+    const cueStats = scoreCueStats(transcriptVTT, translationVTT);
+    const translationStats = scoreTranslationStats(translationVTT, goldTranslation || goldTranscript);
+
+    const accuracyScore = clamp01(codeswitch.f1);
+    const diarScore = 1 - Math.min(1, (diarization.mae || 0) / Math.max(thresholds.diarizationMAE, 0.0001));
+    const cueScore = computeScoreFromDiff(cueStats.targetDiffSec, thresholds.cueTargetDiff);
+    const translationScore = clamp01((translationStats.completeness + translationStats.correctness) / 2);
+    const consistencyScore = average([diarScore, cueScore, translationScore].filter((v)=> Number.isFinite(v)));
+    const overallScore = average([accuracyScore, diarScore, cueScore, translationScore].filter((v)=> Number.isFinite(v)));
+
+    const checks = [];
+    if(normalizeSpans(goldSpans).length){
+      checks.push(codeswitch.f1 >= thresholds.codeswitchF1);
+    }
+    if(boundariesFromSegments(goldDiar).length){
+      checks.push((diarization.mae || 0) <= thresholds.diarizationMAE);
+    }
+    if(parseVttCues(transcriptVTT).length){
+      checks.push(Math.abs(cueStats.targetDiffSec || 0) <= thresholds.cueTargetDiff);
+    }
+    if(parseVttCues(goldTranslation || '').length || parseVttCues(goldTranscript || '').length){
+      checks.push((translationStats.completeness || 0) >= thresholds.translationCompleteness);
+      checks.push((translationStats.correctness || 0) >= thresholds.translationCorrectness);
+    }
+
+    const pass = checks.length ? checks.every(Boolean) : true;
+
+    return {
+      pass,
+      thresholds,
+      accuracyScore,
+      consistencyScore,
+      cueScore,
+      translationScore,
+      overallScore,
+      codeswitch,
+      diarization,
+      cues: cueStats,
+      translation: translationStats
+    };
+  }
+
+  function loadHistory(){
+    try{
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if(!raw) return { entries: [] };
+      const parsed = JSON.parse(raw);
+      if(parsed && Array.isArray(parsed.entries)){
+        return parsed;
+      }
+      return { entries: [] };
+    }catch(err){
+      console.warn('QAMetrics: failed to load history', err);
+      return { entries: [] };
+    }
+  }
+
+  function saveHistory(history){
+    try{
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+    }catch(err){
+      console.warn('QAMetrics: failed to save history', err);
+    }
+  }
+
+  function recordResult(clipId, payload){
+    if(!clipId) return null;
+    const history = loadHistory();
+    const entries = Array.isArray(history.entries) ? history.entries : [];
+    const filtered = entries.filter((entry)=> entry.clipId !== clipId);
+    const now = Date.now();
+    const data = Object.assign({ clipId, ts: now }, payload || {});
+    filtered.push(data);
+    filtered.sort((a,b)=> (a.ts || 0) - (b.ts || 0));
+    const trimmed = filtered.slice(-100);
+    const updated = { entries: trimmed };
+    saveHistory(updated);
+    return updated;
+  }
+
+  function findInManifest(manifest, clipId){
+    if(!manifest || !Array.isArray(manifest.items)) return null;
+    return manifest.items.find((item)=>{
+      const id = item.asset_id || item.id || item.clip_id || item.clipId;
+      return id === clipId;
+    }) || null;
+  }
+
+  function aggregateEntries(entries){
+    const summary = {
+      totalGoldClips: 0,
+      reviewedClips: 0,
+      passCount: 0,
+      averageCodeSwitchF1: 0,
+      averageDiarizationMAE: 0,
+      averageCueLengthSec: 0,
+      averageCueDiffSec: 0,
+      translationCompletenessAvg: 0,
+      translationCorrectnessAvg: 0,
+      overallScore: 0
+    };
+    if(!entries.length){
+      return summary;
+    }
+    const metrics = entries.map((entry)=> entry.metrics || entry.result || {});
+    const qaPayloads = entries.map((entry)=> entry.qa || {});
+    const codeswitchValues = metrics.map((m)=> m.codeswitch && Number.isFinite(m.codeswitch.f1) ? m.codeswitch.f1 : null).filter((v)=> v != null);
+    const diarValues = metrics.map((m)=> m.diarization && Number.isFinite(m.diarization.mae) ? m.diarization.mae : null).filter((v)=> v != null);
+    const cueValues = metrics.map((m)=> m.cues && Number.isFinite(m.cues.avgCueLengthSec) ? m.cues.avgCueLengthSec : null).filter((v)=> v != null);
+    const cueDiffValues = metrics.map((m)=> m.cues && Number.isFinite(m.cues.targetDiffSec) ? m.cues.targetDiffSec : null).filter((v)=> v != null);
+    const translationCompletenessValues = metrics.map((m)=> m.translation && Number.isFinite(m.translation.completeness) ? m.translation.completeness : null).filter((v)=> v != null);
+    const translationCorrectnessValues = metrics.map((m)=> m.translation && Number.isFinite(m.translation.correctness) ? m.translation.correctness : null).filter((v)=> v != null);
+    const translationCharRatioValues = entries.map((entry)=>{
+      const qa = entry.qa || {};
+      if(Number.isFinite(qa.translation_char_ratio)) return qa.translation_char_ratio;
+      const cues = (entry.metrics && entry.metrics.cues) ? entry.metrics.cues : null;
+      return cues && Number.isFinite(cues.translationCompleteness) ? cues.translationCompleteness : null;
+    }).filter((v)=> v != null);
+    const overallValues = metrics.map((m)=> Number.isFinite(m.overallScore) ? m.overallScore : (Number.isFinite(m.translationScore) ? m.translationScore : null)).filter((v)=> v != null);
+
+    summary.totalGoldClips = entries.filter((entry)=> !!(entry.qa && entry.qa.gold_target)).length;
+    summary.reviewedClips = entries.length;
+    summary.passCount = entries.filter((entry)=> entry.qa && entry.qa.gold_check === 'pass').length;
+    summary.averageCodeSwitchF1 = codeswitchValues.length ? average(codeswitchValues) : 0;
+    summary.averageDiarizationMAE = diarValues.length ? average(diarValues) : 0;
+    summary.averageCueLengthSec = cueValues.length ? average(cueValues) : 0;
+    summary.averageCueDiffSec = cueDiffValues.length ? average(cueDiffValues) : 0;
+    summary.translationCompletenessAvg = translationCompletenessValues.length ? average(translationCompletenessValues) : 0;
+    summary.translationCorrectnessAvg = translationCorrectnessValues.length ? average(translationCorrectnessValues) : 0;
+    summary.translationCharRatioAvg = translationCharRatioValues.length ? average(translationCharRatioValues) : 0;
+    summary.overallScore = overallValues.length ? average(overallValues) : 0;
+    summary.passRate = summary.reviewedClips ? summary.passCount / summary.reviewedClips : 0;
+
+    const timeSpentValues = qaPayloads.map((qa)=> Number.isFinite(qa.time_spent_sec) ? qa.time_spent_sec : null).filter((v)=> v != null);
+    summary.averageTimeSpentSec = timeSpentValues.length ? average(timeSpentValues) : 0;
+    return summary;
+  }
+
+  function aggregateByAnnotator(entries){
+    const perAnnotator = new Map();
+    entries.forEach((entry)=>{
+      const qaPayload = entry.qa || {};
+      const annotator = qaPayload.annotator_id || qaPayload.annotator || 'anonymous';
+      if(!perAnnotator.has(annotator)){
+        perAnnotator.set(annotator, []);
+      }
+      perAnnotator.get(annotator).push(entry);
+    });
+    return Array.from(perAnnotator.entries()).map(([annotator, list])=>{
+      const summary = aggregateEntries(list);
+      return Object.assign({ annotator_id: annotator }, summary, { clips: list.length });
+    });
   }
 
   function generateReport(options){
     const opts = options || {};
+    const history = loadHistory();
+    const entries = Array.isArray(history.entries) ? history.entries : [];
     const manifest = opts.manifest || null;
-    const annotations = opts.annotations || {};
-    const clips = selectGoldClips(manifest);
-    const metrics = computeMetrics(clips, { annotations });
 
-    return {
+    const summary = aggregateEntries(entries);
+    const perAnnotator = aggregateByAnnotator(entries);
+
+    const clips = entries.map((entry)=>{
+      const qaPayload = entry.qa || {};
+      const clipId = entry.clipId;
+      const manifestInfo = findInManifest(manifest, clipId) || entry.clip || entry.item || {};
+      const title = manifestInfo.title || manifestInfo.clip_title || manifestInfo.display || clipId || 'Unknown clip';
+      const language = manifestInfo.language || manifestInfo.locale || qaPayload.language || 'unknown';
+      const metrics = entry.metrics || entry.result || {};
+      return {
+        clipId,
+        title,
+        language,
+        qaStatus: qaPayload.gold_check || (metrics.pass ? 'pass' : 'fail'),
+        goldTarget: !!qaPayload.gold_target,
+        timeSpentSec: qaPayload.time_spent_sec || null,
+        metrics: {
+          codeswitch_f1: qaPayload.codeswitch_f1 != null ? qaPayload.codeswitch_f1 : (metrics.codeswitch ? metrics.codeswitch.f1 : null),
+          diarization_mae: qaPayload.diarization_mae != null ? qaPayload.diarization_mae : (metrics.diarization ? metrics.diarization.mae : null),
+          cue_avg_length_sec: metrics.cues ? metrics.cues.avgCueLengthSec : null,
+          cue_diff_sec: metrics.cues ? metrics.cues.targetDiffSec : null,
+          translation_completeness: qaPayload.translation_completeness != null ? qaPayload.translation_completeness : (metrics.translation ? metrics.translation.completeness : null),
+          translation_char_ratio: qaPayload.translation_char_ratio != null ? qaPayload.translation_char_ratio : (metrics.cues ? metrics.cues.translationCompleteness : null),
+          translation_correctness: metrics.translation ? metrics.translation.correctness : null
+        },
+        scores: {
+          accuracy: metrics.accuracyScore,
+          consistency: metrics.consistencyScore,
+          cue: metrics.cueScore,
+          translation: metrics.translationScore,
+          overall: metrics.overallScore
+        }
+      };
+    });
+
+    const report = {
       generatedAt: new Date().toISOString(),
-      annotator: opts.annotator || 'anonymous',
-      summary: {
-        totalGoldClips: metrics.totalGoldClips,
-        reviewedClips: metrics.reviewedClips,
-        accuracyScore: metrics.accuracyScore,
-        consistencyScore: metrics.consistencyScore,
-        notes: metrics.notes
-      },
-      clips: clips.map((clip, index)=>({
-        ...clip,
-        qaStatus: index % 2 === 0 ? 'Pass' : 'Review',
-        comment: 'Placeholder evaluation for development.'
-      }))
+      annotator: opts.annotator || (perAnnotator[0] && perAnnotator[0].annotator_id) || 'anonymous',
+      summary,
+      perAnnotator,
+      clips
     };
+
+    try{
+      localStorage.setItem(REPORT_KEY, JSON.stringify(report));
+    }catch(err){
+      console.warn('QAMetrics: unable to persist report', err);
+    }
+
+    return report;
   }
 
   global.QAMetrics = {
-    selectGoldClips,
-    computeMetrics,
-    generateReport
+    scoreCodeSwitchF1,
+    scoreDiarizationMAE,
+    scoreCueStats,
+    scoreTranslationStats,
+    computeQAResult,
+    recordResult,
+    generateReport,
+    _internal: {
+      parseVttCues,
+      parseRttm,
+      loadHistory,
+      saveHistory
+    }
   };
 })(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- add full QA scoring utilities for code-switching, diarization, cue timing, and translation metrics with persistent history tracking
- integrate gold clip QA evaluation into the Stage 2 submission payload, storing detailed metrics and lint severity
- refresh the QA dashboard and export API to surface per-metric results, annotator aggregates, and generate qa_report.json

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e41e651cdc832885f421a7da697f19