### PR TITLE
Add manifest-driven QA scoring preview

### DIFF
--- a/stage2/app.js
+++ b/stage2/app.js
@@ -1243,6 +1243,7 @@ function bindUI(){
   const diarNext = qs('diarNext'); if(diarNext) diarNext.addEventListener('click', ()=>{ runValidationAndDisplay('screen_review'); show('screen_review'); });
 
   qs('submitBtn').addEventListener('click', async ()=>{
+    const submittedClip = currentItem();
     const transcriptBox = qs('transcriptVTT');
     const translationBox = qs('translationVTT');
     const csBox = qs('codeSwitchVTT');
@@ -1268,7 +1269,11 @@ function bindUI(){
       try{
         const qaReport = window.QAMetrics.generateReport({
           manifest: EAQ.state.manifest,
-          annotations: { lint },
+          annotations: {
+            lint,
+            clip: submittedClip || null,
+            submittedAt: new Date().toISOString()
+          },
           annotator: EAQ.state.annotator
         });
         localStorage.setItem('qa_report', JSON.stringify(qaReport));

--- a/stage2/qa-dashboard.html
+++ b/stage2/qa-dashboard.html
@@ -118,6 +118,17 @@
           ['Reviewed Clips', report.summary && report.summary.reviewedClips != null ? report.summary.reviewedClips : '0'],
           ['Accuracy Score', formatScore(report.summary && report.summary.accuracyScore)],
           ['Consistency Score', formatScore(report.summary && report.summary.consistencyScore)],
+        ];
+        const breakdown = report.summary && report.summary.breakdown;
+        if(breakdown){
+          rows.push(
+            ['Blocking Issues', breakdown.errorCount != null ? String(breakdown.errorCount) : '0'],
+            ['Warnings', breakdown.warningCount != null ? String(breakdown.warningCount) : '0'],
+            ['Translation Gaps', breakdown.translationGaps != null ? String(breakdown.translationGaps) : '0'],
+            ['Code-switch Flags', breakdown.codeSwitchIssues != null ? String(breakdown.codeSwitchIssues) : '0']
+          );
+        }
+        rows.push(
           ['Notes', report.summary && report.summary.notes ? report.summary.notes : 'No notes available']
         ];
         summaryBody.innerHTML = '';

--- a/stage2/qa_metrics.js
+++ b/stage2/qa_metrics.js
@@ -1,24 +1,149 @@
 (function(global){
+  function normalizeClip(item, index){
+    const clipId =
+      item && (item.clipId || item.asset_id || item.id || item.clip_id);
+    const language =
+      (item && (item.language || item.language_hint || item.locale)) || 'unknown';
+    return {
+      clipId: clipId || `clip-${index + 1}`,
+      title:
+        (item && (item.title || item.clip_title || item.asset_id || item.clipId)) ||
+        `Clip ${index + 1}`,
+      language,
+      isGold: !!(item && (item.is_gold || item.isGold)),
+      durationSec:
+        item && item.durationSec != null && Number(item.durationSec) > 0
+          ? Number(item.durationSec)
+          : item && item.media && Number(item.media.duration_sec) > 0
+            ? Number(item.media.duration_sec)
+            : null
+    };
+  }
+
   function selectGoldClips(manifest){
     if(!manifest || !Array.isArray(manifest.items)){
       return [];
     }
-    return manifest.items.slice(0, 3).map((item, index)=>({
-      clipId: item.id || `clip-${index + 1}`,
-      title: item.title || item.clip_title || `Clip ${index + 1}`,
-      language: item.language || 'unknown'
-    }));
+    const goldClips = manifest.items.filter(item=> item && item.is_gold === true);
+    const selection = goldClips.length ? goldClips : manifest.items.slice(0, 3);
+    return selection.map(normalizeClip);
+  }
+
+  function clampScore(value){
+    if(!Number.isFinite(value)) return 0;
+    if(value < 0) return 0;
+    if(value > 1) return 1;
+    return Number(value.toFixed(2));
   }
 
   function computeMetrics(clips, context){
     const totalGoldClips = Array.isArray(clips) ? clips.length : 0;
+    const annotations = (context && context.annotations) || {};
+    const lint = annotations.lint || {};
+    const errorCount = Array.isArray(lint.errors) ? lint.errors.length : 0;
+    const warningCount = Array.isArray(lint.warnings) ? lint.warnings.length : 0;
+    const translationGaps = Array.isArray(lint.translationMissingIndices)
+      ? lint.translationMissingIndices.length
+      : 0;
+    const codeSwitchIssues = Array.isArray(lint.codeSwitchIssues)
+      ? lint.codeSwitchIssues.length
+      : 0;
+
+    const accuracyPenalty = Math.min(1, errorCount * 0.25 + translationGaps * 0.12);
+    const consistencyPenalty = Math.min(1, warningCount * 0.12 + codeSwitchIssues * 0.18);
+
+    const summaryBits = [];
+    if(errorCount){
+      summaryBits.push(`${errorCount} blocking ${errorCount === 1 ? 'issue' : 'issues'}`);
+    }
+    if(warningCount){
+      summaryBits.push(`${warningCount} warning${warningCount === 1 ? '' : 's'}`);
+    }
+    if(translationGaps){
+      summaryBits.push(`${translationGaps} translation gap${translationGaps === 1 ? '' : 's'}`);
+    }
+    if(codeSwitchIssues){
+      summaryBits.push(`${codeSwitchIssues} code-switch flag${codeSwitchIssues === 1 ? '' : 's'}`);
+    }
+
+    const hasSubmission = !!(annotations && annotations.clip);
+    const reviewedClips = hasSubmission
+      ? Math.min(totalGoldClips, 1)
+      : 0;
+
     return {
       totalGoldClips,
-      reviewedClips: Math.min(totalGoldClips, 2),
-      accuracyScore: 0.87,
-      consistencyScore: 0.91,
-      notes: 'Placeholder metrics generated for QA preview.',
+      reviewedClips,
+      accuracyScore: clampScore(1 - accuracyPenalty),
+      consistencyScore: clampScore(1 - consistencyPenalty),
+      notes: summaryBits.length
+        ? `Detected ${summaryBits.join(', ')}.`
+        : 'No blocking QA findings on the latest submission.',
+      breakdown: {
+        errorCount,
+        warningCount,
+        translationGaps,
+        codeSwitchIssues
+      },
       context: context || {}
+    };
+  }
+
+  function buildClipComment(clip, metrics, options){
+    const breakdown = metrics && metrics.breakdown ? metrics.breakdown : {};
+    const currentClipId = options && options.currentClipId;
+    const latestIssues = [];
+    const lint = options && options.annotations && options.annotations.lint;
+    if(breakdown.errorCount){
+      latestIssues.push(`${breakdown.errorCount} blocking ${breakdown.errorCount === 1 ? 'issue' : 'issues'}`);
+    }
+    if(breakdown.warningCount){
+      latestIssues.push(`${breakdown.warningCount} warning${breakdown.warningCount === 1 ? '' : 's'}`);
+    }
+    if(breakdown.translationGaps){
+      latestIssues.push(`${breakdown.translationGaps} translation gap${breakdown.translationGaps === 1 ? '' : 's'}`);
+    }
+    if(breakdown.codeSwitchIssues){
+      latestIssues.push(`${breakdown.codeSwitchIssues} code-switch flag${breakdown.codeSwitchIssues === 1 ? '' : 's'}`);
+    }
+
+    const hasLint = lint && (
+      Array.isArray(lint.errors) ||
+      Array.isArray(lint.warnings) ||
+      Array.isArray(lint.translationMissingIndices) ||
+      Array.isArray(lint.codeSwitchIssues)
+    );
+    const isLatest = currentClipId && clip.clipId === currentClipId;
+
+    if(isLatest && hasLint){
+      if(breakdown.errorCount){
+        return {
+          qaStatus: 'Fail',
+          comment: `Latest submission blocked: ${latestIssues.join(', ')}.`
+        };
+      }
+      if(breakdown.warningCount || breakdown.translationGaps || breakdown.codeSwitchIssues){
+        return {
+          qaStatus: 'Review',
+          comment: `Requires follow-up: ${latestIssues.join(', ')}.`
+        };
+      }
+      return {
+        qaStatus: 'Pass',
+        comment: 'Latest submission cleared automated QA checks.'
+      };
+    }
+
+    if(clip.isGold){
+      return {
+        qaStatus: 'Pending',
+        comment: 'Gold clip queued for verification.'
+      };
+    }
+
+    return {
+      qaStatus: 'Info',
+      comment: 'Awaiting gold evaluation.'
     };
   }
 
@@ -28,6 +153,12 @@
     const annotations = opts.annotations || {};
     const clips = selectGoldClips(manifest);
     const metrics = computeMetrics(clips, { annotations });
+    const currentClipId = annotations && annotations.clip && (
+      annotations.clip.asset_id ||
+      annotations.clip.id ||
+      annotations.clip.clip_id ||
+      annotations.clip.clipId
+    );
 
     return {
       generatedAt: new Date().toISOString(),
@@ -37,13 +168,20 @@
         reviewedClips: metrics.reviewedClips,
         accuracyScore: metrics.accuracyScore,
         consistencyScore: metrics.consistencyScore,
-        notes: metrics.notes
+        notes: metrics.notes,
+        breakdown: metrics.breakdown
       },
-      clips: clips.map((clip, index)=>({
-        ...clip,
-        qaStatus: index % 2 === 0 ? 'Pass' : 'Review',
-        comment: 'Placeholder evaluation for development.'
-      }))
+      clips: clips.map((clip, index)=>{
+        const base = normalizeClip(clip, index);
+        const status = buildClipComment(base, metrics, {
+          annotations,
+          currentClipId
+        });
+        return {
+          ...base,
+          ...status
+        };
+      })
     };
   }
 


### PR DESCRIPTION
## Summary
- derive QA report inputs from manifest gold flags and lint-driven scoring logic
- attach submitted clip context when generating QA reports so statuses reflect the latest submission
- show blocking issue and warning counts on the QA dashboard summary table

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e41e6dcf148328a9b6a7f740e25286