### PR TITLE
Enforce Stage 2 emotion and safety minimum durations

### DIFF
--- a/stage2/index.html
+++ b/stage2/index.html
@@ -193,7 +193,7 @@
         </div>
         <div>
           <h4 style="margin:0 0 .5rem 0;">Safety &amp; PII events</h4>
-          <p style="margin:.25rem 0 0 0;font-size:.9rem;color:var(--muted);">Tap a button at the moment the content occurs. Events are short (0.5&nbsp;s) markers you can drag on the timeline.</p>
+          <p style="margin:.25rem 0 0 0;font-size:.9rem;color:var(--muted);">Tap a button at the moment the content occurs. Events must cover at least 1.5&nbsp;s; drag to adjust if needed.</p>
           <div class="safety-button-grid" id="safetyButtons"></div>
           <label class="flag-toggle"><input type="checkbox" id="clipFlagToggle"> Flag clip for safety review</label>
         </div>


### PR DESCRIPTION
## Summary
- enforce a 1.5 second minimum for Stage 2 emotion and safety spans across validation, editing, and VTT parsing logic, and update the UI copy to match
- add stub helpers that report emotion and safety coverage counts for future QA dashboard integration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4ee8a05d08328937cd309d769f507