### PR TITLE
Add Stage 2 IRR scaffolding and dashboard summary

### DIFF
--- a/scripts/compute_irr.js
+++ b/scripts/compute_irr.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const IRR = require("../stage2/irr.js");
+
+const recordsPath = path.resolve(__dirname, "..", "stage2", "irr_records.json");
+const summaryPath = path.resolve(__dirname, "..", "stage2", "irr_summary.json");
+
+function loadRecords() {
+  try {
+    if (!fs.existsSync(recordsPath)) {
+      return null;
+    }
+    const raw = fs.readFileSync(recordsPath, "utf8");
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (err) {
+    console.warn("compute_irr: unable to read records", err);
+    return null;
+  }
+}
+
+function main() {
+  const records = loadRecords();
+  const summary = IRR.computeIRRSummary(records);
+  try {
+    fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+    console.log(`Wrote IRR summary to ${summaryPath}`);
+  } catch (err) {
+    console.error("compute_irr: failed to write summary", err);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/stage2/app.js
+++ b/stage2/app.js
@@ -1219,6 +1219,35 @@ function currentItem(){
   const m = EAQ.state.manifest; if(!m||!m.items) return null; return m.items[EAQ.state.idx]||null;
 }
 
+function computeDeterministicRatio(input){
+  const text = String(input == null ? '' : input);
+  let hash = 0;
+  for(let i=0; i<text.length; i+=1){
+    hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
+  }
+  return (hash % 1000) / 1000;
+}
+
+function isDoubleCodingRequired(manifestItem){
+  if(!manifestItem) return false;
+  if(manifestItem.double_coded === true) return true;
+  if(manifestItem.double_coded === false) return false;
+  const qaMeta = manifestItem.qa || manifestItem.qa_status || manifestItem.qaStatus || {};
+  const qaPassFlag = manifestItem.qa_pass;
+  if(qaMeta && qaMeta.pass === false){ manifestItem.double_coded = true; return true; }
+  if(qaMeta && typeof qaMeta.pass === 'string' && qaMeta.pass.toLowerCase() === 'false'){ manifestItem.double_coded = true; return true; }
+  if(qaMeta && typeof qaMeta.status === 'string' && qaMeta.status.toLowerCase() === 'fail'){ manifestItem.double_coded = true; return true; }
+  if(qaPassFlag === false){ manifestItem.double_coded = true; return true; }
+  if(typeof qaPassFlag === 'string' && qaPassFlag.toLowerCase() === 'false'){ manifestItem.double_coded = true; return true; }
+  if(typeof qaPassFlag === 'string' && qaPassFlag.toLowerCase() === 'fail'){ manifestItem.double_coded = true; return true; }
+  const clipId = manifestItem.asset_id || manifestItem.id || manifestItem.clip_id || manifestItem.clipId || '';
+  const seedIndex = typeof EAQ !== 'undefined' && EAQ.state ? EAQ.state.idx : manifestItem.index || 0;
+  const ratio = computeDeterministicRatio(clipId || `${seedIndex}:${manifestItem.media && manifestItem.media.duration_sec || ''}`);
+  const shouldDoubleCode = ratio < 0.1;
+  manifestItem.double_coded = shouldDoubleCode;
+  return shouldDoubleCode;
+}
+
 function prefetchAssetsForItem(item){
   if(!item) return;
   const media = item.media || {};
@@ -1506,6 +1535,8 @@ async function enqueueAndSync(lintReport){
     return false;
   }
   const it = currentItem(); if(!it) return false;
+  const clipId = it.asset_id || it.id || it.clip_id || it.clipId;
+  const doubleCodingRequired = isDoubleCodingRequired(it);
   const csSnapshot = snapshotCodeSwitchSpans();
   const csExports = buildCodeSwitchExports(csSnapshot);
   EAQ.state.codeSwitchVTT = csExports.vtt;
@@ -1544,7 +1575,8 @@ async function enqueueAndSync(lintReport){
       cs_total_duration_sec: csExports.summary.total_duration_sec,
       non_arabic_token_ratio_est: csExports.summary.non_arabic_duration_ratio,
       events_present: (EAQ.state.safetyEvents||[]).length > 0,
-      clipFlagged: !!EAQ.state.clipFlagged
+      clipFlagged: !!EAQ.state.clipFlagged,
+      double_coded: doubleCodingRequired
     },
     qa: {
       annotator_id: EAQ.state.annotator,
@@ -1553,14 +1585,16 @@ async function enqueueAndSync(lintReport){
       gold_target: !!it.gold_target,
       gold_check: !!it.gold_target ? 'pending' : 'not_applicable',
       time_spent_sec: timeSpentSec,
-      clip_id: it.asset_id || it.id || it.clip_id || it.clipId || null,
+      clip_id: clipId || null,
       lint: lintSummary,
       speaker_profiles_total: speakerStats.total,
       speaker_profiles_complete: speakerStats.complete,
-      speaker_profiles_completion_rate: speakerStats.total ? speakerStats.complete / speakerStats.total : 1
+      speaker_profiles_completion_rate: speakerStats.total ? speakerStats.complete / speakerStats.total : 1,
+      double_coded: doubleCodingRequired
     },
     lint: lintSummary,
-    client_meta: { device: navigator.userAgent }
+    client_meta: { device: navigator.userAgent },
+    double_coded: doubleCodingRequired
   };
 
   let qaResult = null;
@@ -1601,7 +1635,33 @@ async function enqueueAndSync(lintReport){
     }
   }
 
-  const clipId = it.asset_id || it.id || it.clip_id || it.clipId;
+  if(doubleCodingRequired && qaResult && window.IRR && typeof window.IRR.recordAnnotation === 'function'){
+    try{
+      const cueDeltaMetric = window.QAMetrics && typeof window.QAMetrics.getCueDelta === 'function'
+        ? window.QAMetrics.getCueDelta(qaResult)
+        : (qaResult.cues && Number.isFinite(qaResult.cues.targetDiffSec) ? qaResult.cues.targetDiffSec : null);
+      const translationMetric = window.QAMetrics && typeof window.QAMetrics.getTranslationCompleteness === 'function'
+        ? window.QAMetrics.getTranslationCompleteness(qaResult)
+        : (qaResult.translation && Number.isFinite(qaResult.translation.completeness) ? qaResult.translation.completeness : null);
+      const irrMetrics = {
+        codeSwitchF1: Number.isFinite(payload.qa.codeswitch_f1) ? payload.qa.codeswitch_f1 : null,
+        diarizationMae: Number.isFinite(payload.qa.diarization_mae) ? payload.qa.diarization_mae : null,
+        cueDeltaSec: Number.isFinite(cueDeltaMetric) ? cueDeltaMetric : null,
+        translationCompleteness: Number.isFinite(translationMetric) ? translationMetric : null
+      };
+      const hasMetric = Object.values(irrMetrics).some((value)=> Number.isFinite(value));
+      if(hasMetric){
+        const annotatorId = EAQ.state.annotator || getAnnotatorId();
+        window.IRR.recordAnnotation(annotatorId, clipId || (it.asset_id || it.id || 'unknown'), irrMetrics);
+        if(typeof window.IRR.saveIRRSummary === 'function'){
+          window.IRR.saveIRRSummary();
+        }
+      }
+    }catch(err){
+      console.warn('IRR: failed to record annotation', err);
+    }
+  }
+
   if(window.QAMetrics && typeof window.QAMetrics.recordResult === 'function'){
     try{
       window.QAMetrics.recordResult(clipId, {

--- a/stage2/index.html
+++ b/stage2/index.html
@@ -257,6 +257,7 @@
   <script src="/public/vtt.js"></script>
   <script src="/public/timeline.js"></script>
   <script src="/public/waveform.js"></script>
+  <script src="/stage2/irr.js"></script>
   <script src="/stage2/qa_metrics.js"></script>
   <script src="/stage2/app.js"></script>
   <script>

--- a/stage2/irr.js
+++ b/stage2/irr.js
@@ -1,0 +1,313 @@
+(function (global) {
+  "use strict";
+
+  const STORAGE_KEY = "stage2_irr_records";
+  const SUMMARY_STORAGE_KEY = "stage2_irr_summary";
+  const DEFAULT_MAX_DIAR_SEC = 5;
+  const DEFAULT_MAX_CUE_DELTA = 4;
+
+  const hasLocalStorage = (function () {
+    try {
+      return typeof localStorage !== "undefined";
+    } catch (err) {
+      return false;
+    }
+  })();
+
+  let cache = null;
+
+  function clamp01(value) {
+    if (!Number.isFinite(value)) return 0;
+    if (value < 0) return 0;
+    if (value > 1) return 1;
+    return value;
+  }
+
+  function clone(obj) {
+    return obj ? JSON.parse(JSON.stringify(obj)) : obj;
+  }
+
+  function loadRecordsFromStorage() {
+    if (!hasLocalStorage) return null;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch (err) {
+      console.warn("IRR: failed to load records", err);
+      return null;
+    }
+  }
+
+  function persistRecords(records) {
+    cache = records;
+    if (hasLocalStorage) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+      } catch (err) {
+        console.warn("IRR: failed to persist records", err);
+      }
+    }
+    return records;
+  }
+
+  function ensureRecords() {
+    if (cache) {
+      return cache;
+    }
+    const stored = loadRecordsFromStorage();
+    cache = normalizeRecords(stored);
+    return cache;
+  }
+
+  function normalizeRecords(records) {
+    if (!records) {
+      return { clips: {} };
+    }
+    if (Array.isArray(records)) {
+      const clips = {};
+      records.forEach((entry) => {
+        if (!entry || !entry.clipId) return;
+        const annotations = {};
+        const items = Array.isArray(entry.annotations)
+          ? entry.annotations
+          : Object.entries(entry.annotations || {}).map(([annotatorId, metrics]) => ({
+              annotatorId,
+              metrics,
+            }));
+        items.forEach((item) => {
+          if (!item || !item.annotatorId) return;
+          annotations[item.annotatorId] = clone(item.metrics) || {};
+        });
+        clips[entry.clipId] = { clipId: entry.clipId, annotations };
+      });
+      return { clips };
+    }
+    if (records.clips) {
+      return {
+        clips: Object.keys(records.clips).reduce((acc, clipId) => {
+          const clip = records.clips[clipId];
+          if (!clip) return acc;
+          const annotations = Array.isArray(clip.annotations)
+            ? clip.annotations.reduce((map, ann) => {
+                if (!ann || !ann.annotatorId) return map;
+                map[ann.annotatorId] = clone(ann.metrics) || {};
+                return map;
+              }, {})
+            : Object.keys(clip.annotations || {}).reduce((map, annotatorId) => {
+                map[annotatorId] = clone(clip.annotations[annotatorId]) || {};
+                return map;
+              }, {});
+          acc[clipId] = { clipId, annotations };
+          return acc;
+        }, {}),
+      };
+    }
+    return { clips: {} };
+  }
+
+  function recordAnnotation(annotatorId, clipId, metrics) {
+    if (!annotatorId || !clipId || !metrics || typeof metrics !== "object") {
+      return;
+    }
+    const records = ensureRecords();
+    const clip = records.clips[clipId] || { clipId, annotations: {} };
+    clip.annotations[annotatorId] = Object.assign({}, metrics, {
+      recordedAt: Date.now(),
+    });
+    records.clips[clipId] = clip;
+    persistRecords(records);
+  }
+
+  function average(values) {
+    const finite = values.filter((v) => Number.isFinite(v));
+    if (!finite.length) return null;
+    const sum = finite.reduce((acc, v) => acc + v, 0);
+    return sum / finite.length;
+  }
+
+  function buildPairs(list) {
+    const pairs = [];
+    for (let i = 0; i < list.length; i += 1) {
+      for (let j = i + 1; j < list.length; j += 1) {
+        pairs.push([list[i], list[j]]);
+      }
+    }
+    return pairs;
+  }
+
+  function computeAlpha(records, options) {
+    const opts = options || {};
+    const maxDiar = Number.isFinite(opts.maxDiarizationSeconds)
+      ? opts.maxDiarizationSeconds
+      : DEFAULT_MAX_DIAR_SEC;
+    const maxCueDelta = Number.isFinite(opts.maxCueDeltaSec)
+      ? opts.maxCueDeltaSec
+      : DEFAULT_MAX_CUE_DELTA;
+
+    const annotations = Array.isArray(records)
+      ? records.filter((entry) => entry && entry.metrics)
+      : Object.keys(records || {}).map((key) => {
+          const entry = records[key];
+          if (!entry) return null;
+          return { annotatorId: key, metrics: entry };
+        });
+
+    const cleaned = annotations.filter((entry) => entry && entry.metrics);
+    if (cleaned.length < 2) {
+      return {
+        codeSwitchAlpha: null,
+        diarizationAlpha: null,
+        cueAlpha: null,
+        translationAlpha: null,
+        overallAlpha: null,
+      };
+    }
+
+    const pairs = buildPairs(cleaned);
+
+    const codeSwitchScores = [];
+    const diarizationScores = [];
+    const cueScores = [];
+    const translationScores = [];
+
+    pairs.forEach(([a, b]) => {
+      const ma = a.metrics || {};
+      const mb = b.metrics || {};
+
+      const f1a = Number(ma.codeSwitchF1);
+      const f1b = Number(mb.codeSwitchF1);
+      if (Number.isFinite(f1a) && Number.isFinite(f1b)) {
+        codeSwitchScores.push(clamp01((f1a + f1b) / 2));
+      }
+
+      const maeA = Number(ma.diarizationMae);
+      const maeB = Number(mb.diarizationMae);
+      if (Number.isFinite(maeA) && Number.isFinite(maeB)) {
+        const invA = clamp01(1 - Math.min(Math.abs(maeA), maxDiar) / maxDiar);
+        const invB = clamp01(1 - Math.min(Math.abs(maeB), maxDiar) / maxDiar);
+        diarizationScores.push((invA + invB) / 2);
+      }
+
+      const cueA = Number(ma.cueDeltaSec);
+      const cueB = Number(mb.cueDeltaSec);
+      if (Number.isFinite(cueA) && Number.isFinite(cueB)) {
+        const scoreA = clamp01(1 - Math.min(Math.abs(cueA), maxCueDelta) / maxCueDelta);
+        const scoreB = clamp01(1 - Math.min(Math.abs(cueB), maxCueDelta) / maxCueDelta);
+        cueScores.push((scoreA + scoreB) / 2);
+      }
+
+      const transA = Number(ma.translationCompleteness);
+      const transB = Number(mb.translationCompleteness);
+      if (Number.isFinite(transA) && Number.isFinite(transB)) {
+        const diff = Math.abs(transA - transB);
+        translationScores.push(clamp01(1 - diff));
+      }
+    });
+
+    const codeSwitchAlpha = average(codeSwitchScores);
+    const diarizationAlpha = average(diarizationScores);
+    const cueAlpha = average(cueScores);
+    const translationAlpha = average(translationScores);
+
+    const components = [codeSwitchAlpha, diarizationAlpha, cueAlpha, translationAlpha].filter(
+      (value) => Number.isFinite(value)
+    );
+    const overallAlpha = components.length ? average(components) : null;
+
+    return {
+      codeSwitchAlpha: codeSwitchAlpha != null ? clamp01(codeSwitchAlpha) : null,
+      diarizationAlpha: diarizationAlpha != null ? clamp01(diarizationAlpha) : null,
+      cueAlpha: cueAlpha != null ? clamp01(cueAlpha) : null,
+      translationAlpha: translationAlpha != null ? clamp01(translationAlpha) : null,
+      overallAlpha: overallAlpha != null ? clamp01(overallAlpha) : null,
+    };
+  }
+
+  function computeIRRSummary(records) {
+    const data = normalizeRecords(records != null ? records : ensureRecords());
+    const clips = data.clips || {};
+    const entries = Object.keys(clips).map((clipId) => clips[clipId]).filter(Boolean);
+
+    let clipCount = 0;
+    const codeSwitchValues = [];
+    const diarizationValues = [];
+    const cueValues = [];
+    const translationValues = [];
+
+    entries.forEach((clip) => {
+      const annotations = clip && clip.annotations ? clip.annotations : {};
+      const annList = Object.keys(annotations).map((annotatorId) => ({
+        annotatorId,
+        metrics: annotations[annotatorId],
+      }));
+      if (annList.length < 2) return;
+      clipCount += 1;
+      const alpha = computeAlpha(annList);
+      if (alpha.codeSwitchAlpha != null) codeSwitchValues.push(alpha.codeSwitchAlpha);
+      if (alpha.diarizationAlpha != null) diarizationValues.push(alpha.diarizationAlpha);
+      if (alpha.cueAlpha != null) cueValues.push(alpha.cueAlpha);
+      if (alpha.translationAlpha != null) translationValues.push(alpha.translationAlpha);
+    });
+
+    const codeSwitchAlpha = codeSwitchValues.length ? average(codeSwitchValues) : null;
+    const diarizationAlpha = diarizationValues.length ? average(diarizationValues) : null;
+    const cueAlpha = cueValues.length ? average(cueValues) : null;
+    const translationAlpha = translationValues.length ? average(translationValues) : null;
+
+    const components = [codeSwitchAlpha, diarizationAlpha, cueAlpha, translationAlpha].filter((value) =>
+      Number.isFinite(value)
+    );
+    const overallAlpha = components.length ? average(components) : null;
+
+    return {
+      generatedAt: new Date().toISOString(),
+      clipsEvaluated: clipCount,
+      codeSwitchAlpha: codeSwitchAlpha != null ? clamp01(codeSwitchAlpha) : null,
+      diarizationAlpha: diarizationAlpha != null ? clamp01(diarizationAlpha) : null,
+      cueAlpha: cueAlpha != null ? clamp01(cueAlpha) : null,
+      translationAlpha: translationAlpha != null ? clamp01(translationAlpha) : null,
+      overallAlpha: overallAlpha != null ? clamp01(overallAlpha) : null,
+    };
+  }
+
+  function saveIRRSummary(options) {
+    const opts = options || {};
+    const summary = computeIRRSummary(opts.records);
+    if (hasLocalStorage) {
+      try {
+        localStorage.setItem(SUMMARY_STORAGE_KEY, JSON.stringify(summary));
+      } catch (err) {
+        console.warn("IRR: failed to persist summary", err);
+      }
+    }
+    if (opts.path) {
+      try {
+        const fs = require("fs");
+        const path = require("path");
+        const targetPath = path.resolve(opts.path);
+        fs.writeFileSync(targetPath, JSON.stringify(summary, null, 2));
+      } catch (err) {
+        console.warn("IRR: unable to write summary to disk", err);
+      }
+    }
+    return summary;
+  }
+
+  const api = {
+    recordAnnotation,
+    computeAlpha,
+    computeIRRSummary,
+    saveIRRSummary,
+    _internal: {
+      normalizeRecords,
+      ensureRecords,
+    },
+  };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  } else {
+    global.IRR = api;
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/stage2/qa-dashboard.html
+++ b/stage2/qa-dashboard.html
@@ -87,6 +87,22 @@
         </thead>
         <tbody></tbody>
       </table>
+      <div class="qa-dashboard__empty hide" id="irrSummaryEmpty" role="status">No IRR data yet.</div>
+      <table class="qa-report-table hide" id="irrSummaryTable">
+        <caption>IRR Summary</caption>
+        <thead>
+          <tr>
+            <th scope="col">Clips</th>
+            <th scope="col">Code-Switch α</th>
+            <th scope="col">Diarization α</th>
+            <th scope="col">Cue α</th>
+            <th scope="col">Translation α</th>
+            <th scope="col">Overall α</th>
+            <th scope="col">Generated</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
       <table class="qa-report-table hide" id="qaAnnotatorsTable">
         <caption>Per-Annotator Averages</caption>
         <thead>
@@ -187,6 +203,7 @@
   </div>
   <script src="/public/env.js"></script>
   <script src="/public/config.js"></script>
+  <script src="/stage2/irr.js"></script>
   <script src="/stage2/qa_metrics.js"></script>
   <script>
     (function(){
@@ -220,6 +237,10 @@
       const reviewSummaryNode = document.getElementById('qaReviewSummary');
       const flaggedCountNode = document.getElementById('qaReviewFlaggedCount');
       const reviewButton = document.getElementById('qaReviewButton');
+      const irrSummaryKey = 'stage2_irr_summary';
+      const irrSummaryTable = document.getElementById('irrSummaryTable');
+      const irrSummaryBody = irrSummaryTable ? irrSummaryTable.querySelector('tbody') : null;
+      const irrEmptyState = document.getElementById('irrSummaryEmpty');
 
       function safeParse(raw){
         if(!raw) return null;
@@ -249,6 +270,74 @@
         if(typeof value !== 'number' || !Number.isFinite(value)) return 'N/A';
         return `${value.toFixed(digits)} s`;
       };
+      const formatAlpha = (value, digits = 2)=>{
+        if(typeof value !== 'number' || !Number.isFinite(value)) return '—';
+        return value.toFixed(digits);
+      };
+
+      function loadIrrSummaryLocal(){
+        try{
+          const raw = localStorage.getItem(irrSummaryKey);
+          return safeParse(raw);
+        }catch(err){
+          console.warn('Failed to load IRR summary from storage', err);
+          return null;
+        }
+      }
+
+      async function fetchIrrSummaryFile(){
+        try{
+          const res = await fetch('/stage2/irr_summary.json', { cache: 'no-store' });
+          if(!res || !res.ok) return null;
+          return await res.json();
+        }catch(err){
+          return null;
+        }
+      }
+
+      function renderIrrSummary(summary){
+        if(!irrSummaryTable || !irrSummaryBody){ return; }
+        irrSummaryBody.innerHTML = '';
+        if(!summary){
+          irrSummaryTable.classList.add('hide');
+          if(irrEmptyState){ irrEmptyState.classList.remove('hide'); }
+          return;
+        }
+        const row = document.createElement('tr');
+        const cells = [
+          summary.clipsEvaluated != null ? summary.clipsEvaluated : '0',
+          formatAlpha(summary.codeSwitchAlpha),
+          formatAlpha(summary.diarizationAlpha),
+          formatAlpha(summary.cueAlpha),
+          formatAlpha(summary.translationAlpha),
+          formatAlpha(summary.overallAlpha),
+          summary.generatedAt ? new Date(summary.generatedAt).toLocaleString() : '—'
+        ];
+        cells.forEach((value)=>{
+          const td = document.createElement('td');
+          td.textContent = value;
+          row.appendChild(td);
+        });
+        irrSummaryBody.appendChild(row);
+        irrSummaryTable.classList.remove('hide');
+        if(irrEmptyState){ irrEmptyState.classList.add('hide'); }
+      }
+
+      function refreshIrrSummary(){
+        const localSummary = loadIrrSummaryLocal();
+        if(localSummary){
+          renderIrrSummary(localSummary);
+          return;
+        }
+        renderIrrSummary(null);
+        if(typeof fetch === 'function'){
+          fetchIrrSummaryFile().then((summary)=>{
+            if(summary){
+              renderIrrSummary(summary);
+            }
+          });
+        }
+      }
 
       function renderSummaryTable(report){
         if(!summaryTable || !summaryBody){ return; }
@@ -434,6 +523,7 @@
       }
 
       function render(report){
+        refreshIrrSummary();
         if(!report){
           if(emptyState){ emptyState.classList.remove('hide'); }
           if(summaryTable){ summaryTable.classList.add('hide'); }

--- a/stage2/qa_metrics.js
+++ b/stage2/qa_metrics.js
@@ -1096,6 +1096,27 @@
     return report;
   }
 
+  function getCueDelta(metrics) {
+    if (!metrics) return null;
+    const cues = metrics.cues || {};
+    if (Number.isFinite(cues.targetDiffSec)) return cues.targetDiffSec;
+    if (Number.isFinite(cues.avgCueDiffSec)) return cues.avgCueDiffSec;
+    if (Number.isFinite(metrics.cue_diff_sec)) return metrics.cue_diff_sec;
+    if (Number.isFinite(metrics.cueAvgDiffSec)) return metrics.cueAvgDiffSec;
+    return null;
+  }
+
+  function getTranslationCompleteness(metrics) {
+    if (!metrics) return null;
+    const translation = metrics.translation || {};
+    if (Number.isFinite(translation.completeness)) return translation.completeness;
+    if (Number.isFinite(metrics.translation_completeness)) return metrics.translation_completeness;
+    const cues = metrics.cues || {};
+    if (Number.isFinite(cues.translationCompleteness)) return cues.translationCompleteness;
+    if (Number.isFinite(metrics.translationCompleteness)) return metrics.translationCompleteness;
+    return null;
+  }
+
   // ------------------------------
   // Public API
   // ------------------------------
@@ -1107,6 +1128,8 @@
     computeQAResult,
     recordResult,
     generateReport,
+    getCueDelta,
+    getTranslationCompleteness,
     _internal: {
       parseVttCues,
       parseRttm,


### PR DESCRIPTION
## Summary
- add a Stage 2 IRR module to accumulate annotations, compute simple alpha scores, and persist summaries
- flag double-coded submissions in the Stage 2 app, record IRR metrics during submission, and expose new QA metric helpers
- surface IRR results on the QA dashboard and add a compute_irr script for offline summary generation

## Testing
- node scripts/compute_irr.js

------
https://chatgpt.com/codex/tasks/task_e_68e4f209b0648328a45fdbf6132cc869