### PR TITLE
Add Stage 2 coverage summary pipeline and dashboard view

### DIFF
--- a/scripts/compute_coverage.js
+++ b/scripts/compute_coverage.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { parseArgs } = require('util');
+
+function readJsonl(datasetPath) {
+  if (!fs.existsSync(datasetPath)) {
+    throw new Error(`Dataset not found at ${datasetPath}`);
+  }
+  const content = fs.readFileSync(datasetPath, 'utf-8');
+  const lines = content.split(/\r?\n/);
+  const records = [];
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    try {
+      records.push(JSON.parse(trimmed));
+    } catch (err) {
+      throw new Error(`Failed to parse JSON on line ${index + 1}: ${err.message}`);
+    }
+  });
+  return records;
+}
+
+function asArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'object') {
+    if (Array.isArray(value.profiles)) return value.profiles;
+    if (Array.isArray(value.speakers)) return value.speakers;
+    return Object.values(value);
+  }
+  return [];
+}
+
+function getFirst(obj, keys) {
+  if (!obj) return undefined;
+  for (const key of keys) {
+    if (obj[key] != null) {
+      return obj[key];
+    }
+  }
+  return undefined;
+}
+
+function normalizeCategory(value) {
+  if (value == null) return 'unknown';
+  const str = String(value).trim();
+  if (!str) return 'unknown';
+  return str.toLowerCase();
+}
+
+function loadProfilesFromFile(record, datasetDir) {
+  const files = record && record.files ? record.files : {};
+  const profilePathRaw =
+    files['speaker_profiles.json'] || files.speaker_profiles || files.speakerProfiles;
+  if (!profilePathRaw) {
+    return [];
+  }
+  const resolved = path.resolve(datasetDir, profilePathRaw);
+  if (!fs.existsSync(resolved)) {
+    return [];
+  }
+  try {
+    const text = fs.readFileSync(resolved, 'utf-8');
+    const parsed = JSON.parse(text);
+    return asArray(parsed);
+  } catch (err) {
+    console.warn(`Warning: failed to read speaker profiles at ${resolved}: ${err.message}`);
+    return [];
+  }
+}
+
+function extractSpeakerProfiles(record, datasetDir) {
+  const profiles = [];
+  profiles.push(...asArray(record && record.speaker_profiles));
+  profiles.push(...asArray(record && record.speakerProfiles));
+  profiles.push(...loadProfilesFromFile(record, datasetDir));
+  return profiles.filter(Boolean);
+}
+
+function computeCoverageSummary(options) {
+  if (!options || !options.datasetPath) {
+    throw new Error('datasetPath is required');
+  }
+  const datasetPath = path.resolve(options.datasetPath);
+  const datasetDir = options.datasetDir
+    ? path.resolve(options.datasetDir)
+    : path.dirname(datasetPath);
+
+  const records = readJsonl(datasetPath);
+  const combinationCounts = new Map();
+  let totalProfiles = 0;
+
+  records.forEach((record) => {
+    const profiles = extractSpeakerProfiles(record, datasetDir);
+    profiles.forEach((profile) => {
+      if (!profile || typeof profile !== 'object') {
+        return;
+      }
+      const dialectFamily = normalizeCategory(
+        getFirst(profile, ['dialect_family', 'dialectFamily', 'dialect_family_code'])
+      );
+      const dialectSubregion = normalizeCategory(
+        getFirst(profile, ['dialect_subregion', 'dialectSubregion', 'dialect'])
+      );
+      const gender = normalizeCategory(
+        getFirst(profile, ['apparent_gender', 'gender', 'gender_norm'])
+      );
+      const ageBand = normalizeCategory(
+        getFirst(profile, ['apparent_age_band', 'age_band', 'age'])
+      );
+
+      const key = `${dialectFamily}||${dialectSubregion}||${gender}||${ageBand}`;
+      combinationCounts.set(key, (combinationCounts.get(key) || 0) + 1);
+      totalProfiles += 1;
+    });
+  });
+
+  const coverage = Array.from(combinationCounts.entries())
+    .map(([key, count]) => {
+      const [dialectFamily, dialectSubregion, gender, ageBand] = key.split('||');
+      return {
+        dialect_family: dialectFamily,
+        dialect_subregion: dialectSubregion,
+        gender,
+        age_band: ageBand,
+        count,
+      };
+    })
+    .sort((a, b) => b.count - a.count || a.dialect_family.localeCompare(b.dialect_family));
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    total_profiles: totalProfiles,
+    coverage,
+  };
+
+  return summary;
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      dataset: { type: 'string', short: 'd' },
+      out: { type: 'string', short: 'o' },
+    },
+  });
+
+  const datasetPath = values.dataset || values.d || null;
+  if (!datasetPath) {
+    console.error('Error: --dataset path is required.');
+    process.exit(1);
+  }
+
+  const outputLocation = path.resolve(
+    values.out || values.o || path.join(path.dirname(path.resolve(datasetPath)), 'coverage_summary.json')
+  );
+  const summary = computeCoverageSummary({
+    datasetPath,
+  });
+  fs.writeFileSync(outputLocation, JSON.stringify(summary, null, 2));
+  console.log(`Coverage summary written to ${outputLocation}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { computeCoverageSummary };

--- a/scripts/export_dataset.js
+++ b/scripts/export_dataset.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { parseArgs } = require('util');
+const { computeCoverageSummary } = require('./compute_coverage');
 
 function listSubdirs(root) {
   if (!fs.existsSync(root)) {
@@ -352,6 +353,7 @@ function main() {
 
   const datasetJsonlPath = path.join(datasetRoot, 'dataset.jsonl');
   const qaSummaryPath = path.join(datasetRoot, 'qa_summary.json');
+  const coverageSummaryPath = path.join(datasetRoot, 'coverage_summary.json');
   const datasetCardPath = path.join(datasetRoot, 'dataset_card.md');
   const trainingSummaryPath = path.join(datasetRoot, 'training_data_summary.json');
   const exportLogPath = path.join(datasetRoot, 'export_log.txt');
@@ -371,6 +373,13 @@ function main() {
     std_cue_delta_sec: datasetRecords.length ? std(qaGlobal.cueDeltaValues) : 0,
   };
   fs.writeFileSync(qaSummaryPath, JSON.stringify(qaSummary, null, 2));
+
+  try {
+    const coverageSummary = computeCoverageSummary({ datasetPath: datasetJsonlPath });
+    fs.writeFileSync(coverageSummaryPath, JSON.stringify(coverageSummary, null, 2));
+  } catch (err) {
+    console.warn('Warning: failed to compute coverage summary', err);
+  }
 
   const durationHours = totalDurationSec / 3600;
   const splitLines = Object.entries(splitCounts)

--- a/stage2/qa-dashboard.html
+++ b/stage2/qa-dashboard.html
@@ -377,6 +377,142 @@
     return summary;
   }
 
+  function formatCoverageLabel(value) {
+    if (!value || value === 'unknown') return 'Unknown';
+    const text = String(value)
+      .trim()
+      .replace(/[_\s]+/g, ' ')
+      .toLowerCase();
+    return text.replace(/\b([a-z])/g, (match, letter) => letter.toUpperCase());
+  }
+
+  function ensureCoverageContainer() {
+    if (typeof document === 'undefined') return null;
+    let container = document.getElementById('coverageSummary');
+    if (!container) {
+      container = document.createElement('section');
+      container.id = 'coverageSummary';
+      container.className = 'coverage-summary';
+      if (document.body) {
+        document.body.insertBefore(container, document.body.firstChild || null);
+      }
+    }
+    return container;
+  }
+
+  function injectCoverageStyles() {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById('coverageSummaryStyles')) return;
+    const style = document.createElement('style');
+    style.id = 'coverageSummaryStyles';
+    style.textContent = `
+      .coverage-summary { max-width: 920px; margin: 1.5rem auto; padding: 1rem; background: var(--card, #fff); border-radius: 12px; border: 1px solid var(--border, #dcdcdc); box-shadow: 0 4px 24px rgba(0, 0, 0, 0.04); }
+      .coverage-summary h2 { margin: 0 0 .75rem 0; font-size: 1.25rem; }
+      .coverage-summary__meta { margin: 0 0 1rem 0; color: var(--muted, #555); }
+      .coverage-summary__table { width: 100%; border-collapse: collapse; font-size: .95rem; }
+      .coverage-summary__table th, .coverage-summary__table td { padding: .5rem .65rem; border: 1px solid var(--border, #e2e2e2); text-align: left; }
+      .coverage-summary__table th { background: rgba(0,0,0,0.04); font-weight: 600; }
+      .coverage-summary__empty { margin: 0; color: var(--muted, #666); }
+    `;
+    (document.head || document.body || document.documentElement).appendChild(style);
+  }
+
+  function renderCoverageTable(summary) {
+    const container = ensureCoverageContainer();
+    if (!container) return;
+    injectCoverageStyles();
+    container.innerHTML = '';
+
+    const heading = document.createElement('h2');
+    heading.textContent = 'Coverage summary';
+    container.appendChild(heading);
+
+    const meta = document.createElement('p');
+    meta.className = 'coverage-summary__meta';
+    const total = Number(summary && summary.total_profiles);
+    meta.textContent = Number.isFinite(total)
+      ? `Total speaker profiles: ${total}`
+      : 'Coverage summary by speaker profile attributes.';
+    container.appendChild(meta);
+
+    const coverage = Array.isArray(summary && summary.coverage) ? summary.coverage : [];
+    if (!coverage.length) {
+      const empty = document.createElement('p');
+      empty.className = 'coverage-summary__empty';
+      empty.textContent = 'No coverage information available.';
+      container.appendChild(empty);
+      return;
+    }
+
+    const table = document.createElement('table');
+    table.className = 'coverage-summary__table';
+
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    ['Dialect family', 'Dialect subregion', 'Gender', 'Age band', 'Count'].forEach((label) => {
+      const cell = document.createElement('th');
+      cell.textContent = label;
+      headerRow.appendChild(cell);
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    coverage.forEach((entry) => {
+      const row = document.createElement('tr');
+      const cells = [
+        formatCoverageLabel(entry.dialect_family),
+        formatCoverageLabel(entry.dialect_subregion),
+        formatCoverageLabel(entry.gender),
+        formatCoverageLabel(entry.age_band),
+        Number(entry.count) || 0,
+      ];
+      cells.forEach((value) => {
+        const cell = document.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+  }
+
+  function fetchCoverageSummary() {
+    if (typeof fetch !== 'function') {
+      return Promise.resolve(null);
+    }
+    return fetch('coverage_summary.json', { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) return null;
+        return response.json().catch(() => null);
+      })
+      .catch(() => null);
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('DOMContentLoaded', () => {
+      fetchCoverageSummary().then((summary) => {
+        if (summary) {
+          renderCoverageTable(summary);
+        } else {
+          const container = ensureCoverageContainer();
+          if (container) {
+            injectCoverageStyles();
+            container.innerHTML = '';
+            const heading = document.createElement('h2');
+            heading.textContent = 'Coverage summary';
+            container.appendChild(heading);
+            const empty = document.createElement('p');
+            empty.className = 'coverage-summary__empty';
+            empty.textContent = 'Coverage summary not available.';
+            container.appendChild(empty);
+          }
+        }
+      });
+    });
+  }
+
   // --- Public API ------------------------------------------------------------
   const api = {
     recordAnnotation,


### PR DESCRIPTION
## Summary
- add a compute_coverage.js helper to count dialect, subregion, gender, and age coverage from exported dataset.jsonl files
- invoke the new coverage computation from export_dataset.js so coverage_summary.json is produced alongside other export artifacts
- render the coverage summary in qa-dashboard.html as a simple table fed by coverage_summary.json

## Testing
- node scripts/compute_coverage.js --dataset /tmp/test_dataset/dataset.jsonl
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4fd14603883289aca0cf43f0920c0