### PR TITLE
Add coverage heatmap metrics and dashboard visualization

### DIFF
--- a/stage2/qa-dashboard.html
+++ b/stage2/qa-dashboard.html
@@ -386,6 +386,108 @@
     return text.replace(/\b([a-z])/g, (match, letter) => letter.toUpperCase());
   }
 
+  const COVERAGE_QUOTA_TARGETS = {
+    default: 25,
+    byDialectFamily: {},
+    bySubregion: {},
+    byCombination: {},
+  };
+
+  function getCoverageTarget(dialectFamily, subregion) {
+    const comboKey = `${dialectFamily}||${subregion}`;
+    const combinationOverride = COVERAGE_QUOTA_TARGETS.byCombination[comboKey];
+    if (Number.isFinite(combinationOverride)) {
+      return combinationOverride;
+    }
+    const familyOverride = COVERAGE_QUOTA_TARGETS.byDialectFamily[dialectFamily];
+    if (Number.isFinite(familyOverride)) {
+      return familyOverride;
+    }
+    const subregionOverride = COVERAGE_QUOTA_TARGETS.bySubregion[subregion];
+    if (Number.isFinite(subregionOverride)) {
+      return subregionOverride;
+    }
+    return COVERAGE_QUOTA_TARGETS.default;
+  }
+
+  function aggregateCoverageCombinations(summary) {
+    const rowsByKey = {};
+    const heatmap = summary && summary.coverage_heatmap;
+    const totalProfiles = Number(summary && summary.total_profiles) || 0;
+
+    const pushRow = (dialectFamily, subregion, increment) => {
+      const key = `${dialectFamily}||${subregion}`;
+      if (!rowsByKey[key]) {
+        rowsByKey[key] = {
+          dialectFamily,
+          subregion,
+          count: 0,
+        };
+      }
+      rowsByKey[key].count += increment;
+    };
+
+    if (heatmap && typeof heatmap === 'object') {
+      Object.entries(heatmap).forEach(([dialectFamily, subregions]) => {
+        if (!subregions || typeof subregions !== 'object') {
+          return;
+        }
+        Object.entries(subregions).forEach(([subregion, genders]) => {
+          if (!genders || typeof genders !== 'object') {
+            return;
+          }
+          let total = 0;
+          Object.values(genders).forEach((ageBands) => {
+            if (!ageBands || typeof ageBands !== 'object') {
+              return;
+            }
+            Object.values(ageBands).forEach((value) => {
+              const numeric = Number(value);
+              if (Number.isFinite(numeric)) {
+                total += numeric;
+              }
+            });
+          });
+          pushRow(dialectFamily, subregion, total);
+        });
+      });
+    } else if (Array.isArray(summary && summary.coverage)) {
+      summary.coverage.forEach((entry) => {
+        if (!entry) return;
+        const dialectFamily = entry.dialect_family || 'unknown';
+        const subregion = entry.dialect_subregion || 'unknown';
+        const count = Number(entry.count) || 0;
+        pushRow(dialectFamily, subregion, count);
+      });
+    }
+
+    const rows = Object.values(rowsByKey).map((row) => {
+      const target = getCoverageTarget(row.dialectFamily, row.subregion);
+      const progressRatio = target > 0 ? row.count / target : 0;
+      const proportion = totalProfiles > 0 ? row.count / totalProfiles : 0;
+      const status = progressRatio >= 1 ? 'met' : progressRatio >= 0.6 ? 'partial' : 'low';
+      return {
+        ...row,
+        target,
+        progressRatio,
+        proportion,
+        status,
+      };
+    });
+
+    rows.sort(
+      (a, b) =>
+        a.dialectFamily.localeCompare(b.dialectFamily) ||
+        a.subregion.localeCompare(b.subregion)
+    );
+
+    return rows;
+  }
+
+  function describeCoverageCombination(row) {
+    return `${formatCoverageLabel(row.dialectFamily)} / ${formatCoverageLabel(row.subregion)}`;
+  }
+
   function ensureCoverageContainer() {
     if (typeof document === 'undefined') return null;
     let container = document.getElementById('coverageSummary');
@@ -414,9 +516,26 @@
       .coverage-summary { max-width: 920px; margin: 1.5rem auto; padding: 1rem; background: var(--card, #fff); border-radius: 12px; border: 1px solid var(--border, #dcdcdc); box-shadow: 0 4px 24px rgba(0, 0, 0, 0.04); }
       .coverage-summary h2 { margin: 0 0 .75rem 0; font-size: 1.25rem; }
       .coverage-summary__meta { margin: 0 0 1rem 0; color: var(--muted, #555); }
+      .coverage-summary__insight { margin: 0 0 .75rem 0; font-size: .9rem; color: var(--muted, #555); }
+      .coverage-summary__legend { margin: 0 0 1rem 0; display: flex; flex-wrap: wrap; gap: .5rem 1rem; font-size: .8rem; color: var(--muted, #555); }
+      .coverage-summary__legend-item { display: inline-flex; align-items: center; gap: .35rem; }
+      .coverage-summary__legend-swatch { width: 12px; height: 12px; border-radius: 999px; display: inline-block; }
+      .coverage-summary__legend-swatch--met { background: #2e7d32; }
+      .coverage-summary__legend-swatch--partial { background: #f9a825; }
+      .coverage-summary__legend-swatch--low { background: #d32f2f; }
       .coverage-summary__table { width: 100%; border-collapse: collapse; font-size: .95rem; }
-      .coverage-summary__table th, .coverage-summary__table td { padding: .5rem .65rem; border: 1px solid var(--border, #e2e2e2); text-align: left; }
+      .coverage-summary__table th, .coverage-summary__table td { padding: .5rem .65rem; border: 1px solid var(--border, #e2e2e2); text-align: left; vertical-align: top; }
       .coverage-summary__table th { background: rgba(0,0,0,0.04); font-weight: 600; }
+      .coverage-summary__cell--count { font-weight: 600; }
+      .coverage-summary__row--met .coverage-summary__cell--count { color: #2e7d32; }
+      .coverage-summary__row--partial .coverage-summary__cell--count { color: #f9a825; }
+      .coverage-summary__row--low .coverage-summary__cell--count { color: #d32f2f; }
+      .coverage-summary__progress { position: relative; background: rgba(0,0,0,0.08); border-radius: 999px; height: 12px; overflow: hidden; }
+      .coverage-summary__progress-fill { height: 100%; border-radius: inherit; background: var(--accent, #2b7cff); transition: width .3s ease; }
+      .coverage-summary__row--met .coverage-summary__progress-fill { background: #2e7d32; }
+      .coverage-summary__row--partial .coverage-summary__progress-fill { background: #f9a825; }
+      .coverage-summary__row--low .coverage-summary__progress-fill { background: #d32f2f; }
+      .coverage-summary__progress-label { display: block; margin-top: .25rem; font-size: .75rem; color: var(--muted, #666); }
       .coverage-summary__empty { margin: 0; color: var(--muted, #666); }
     `;
     (document.head || document.body || document.documentElement).appendChild(style);
@@ -440,8 +559,8 @@
       : 'Coverage summary by speaker profile attributes.';
     container.appendChild(meta);
 
-    const coverage = Array.isArray(summary && summary.coverage) ? summary.coverage : [];
-    if (!coverage.length) {
+    const rows = aggregateCoverageCombinations(summary);
+    if (!rows.length) {
       const empty = document.createElement('p');
       empty.className = 'coverage-summary__empty';
       empty.textContent = 'No coverage information available.';
@@ -449,12 +568,52 @@
       return;
     }
 
+    const insight = document.createElement('p');
+    insight.className = 'coverage-summary__insight';
+    const met = rows.filter((row) => row.status === 'met');
+    const partial = rows.filter((row) => row.status === 'partial');
+    const low = rows.filter((row) => row.status === 'low');
+    const listToText = (list) =>
+      list.length ? list.slice(0, 3).map((row) => describeCoverageCombination(row)).join(', ') : 'None';
+    const parts = [
+      `Well-covered: ${listToText(met)}.`,
+      partial.length ? `Building coverage: ${listToText(partial)}.` : '',
+      `Needs focus: ${listToText(low)}.`,
+    ].filter(Boolean);
+    insight.textContent = parts.join(' ');
+    container.appendChild(insight);
+
+    const legend = document.createElement('div');
+    legend.className = 'coverage-summary__legend';
+    [
+      { key: 'met', label: 'Target met' },
+      { key: 'partial', label: 'Approaching target' },
+      { key: 'low', label: 'Needs attention' },
+    ].forEach((entry) => {
+      const item = document.createElement('span');
+      item.className = 'coverage-summary__legend-item';
+      const swatch = document.createElement('span');
+      swatch.className = `coverage-summary__legend-swatch coverage-summary__legend-swatch--${entry.key}`;
+      const text = document.createElement('span');
+      text.textContent = entry.label;
+      item.appendChild(swatch);
+      item.appendChild(text);
+      legend.appendChild(item);
+    });
+    container.appendChild(legend);
+
     const table = document.createElement('table');
     table.className = 'coverage-summary__table';
 
     const thead = document.createElement('thead');
     const headerRow = document.createElement('tr');
-    ['Dialect family', 'Dialect subregion', 'Gender', 'Age band', 'Count'].forEach((label) => {
+    [
+      'Dialect family',
+      'Dialect subregion',
+      'Count',
+      'Target',
+      'Progress toward quota',
+    ].forEach((label) => {
       const cell = document.createElement('th');
       cell.textContent = label;
       headerRow.appendChild(cell);
@@ -463,21 +622,53 @@
     table.appendChild(thead);
 
     const tbody = document.createElement('tbody');
-    coverage.forEach((entry) => {
-      const row = document.createElement('tr');
-      const cells = [
-        formatCoverageLabel(entry.dialect_family),
-        formatCoverageLabel(entry.dialect_subregion),
-        formatCoverageLabel(entry.gender),
-        formatCoverageLabel(entry.age_band),
-        Number(entry.count) || 0,
-      ];
-      cells.forEach((value) => {
-        const cell = document.createElement('td');
-        cell.textContent = value;
-        row.appendChild(cell);
-      });
-      tbody.appendChild(row);
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+      tr.className = `coverage-summary__row coverage-summary__row--${row.status}`;
+
+      const familyCell = document.createElement('td');
+      familyCell.textContent = formatCoverageLabel(row.dialectFamily);
+      tr.appendChild(familyCell);
+
+      const subregionCell = document.createElement('td');
+      subregionCell.textContent = formatCoverageLabel(row.subregion);
+      tr.appendChild(subregionCell);
+
+      const countCell = document.createElement('td');
+      countCell.className = 'coverage-summary__cell coverage-summary__cell--count';
+      countCell.textContent = `${row.count}`;
+      tr.appendChild(countCell);
+
+      const targetCell = document.createElement('td');
+      targetCell.textContent = Number.isFinite(row.target) ? `${Math.round(row.target)}` : '—';
+      tr.appendChild(targetCell);
+
+      const progressCell = document.createElement('td');
+      progressCell.className = 'coverage-summary__cell coverage-summary__cell--progress';
+      const progress = document.createElement('div');
+      progress.className = 'coverage-summary__progress';
+      const progressFill = document.createElement('div');
+      progressFill.className = 'coverage-summary__progress-fill';
+      const progressPercent = Math.max(0, Math.min(row.progressRatio, 1));
+      progressFill.style.width = `${(progressPercent * 100).toFixed(1)}%`;
+      progress.appendChild(progressFill);
+      progressCell.appendChild(progress);
+
+      const progressLabel = document.createElement('span');
+      progressLabel.className = 'coverage-summary__progress-label';
+      const targetPercent = row.progressRatio * 100;
+      const datasetPercent = row.proportion * 100;
+      const targetText = Number.isFinite(targetPercent)
+        ? `${targetPercent.toFixed(targetPercent >= 100 ? 0 : 1)}% of target`
+        : 'Target unavailable';
+      const datasetText = Number.isFinite(datasetPercent)
+        ? `${datasetPercent.toFixed(datasetPercent >= 10 ? 1 : 2)}% of dataset`
+        : '';
+      progressLabel.textContent = datasetText ? `${targetText} • ${datasetText}` : targetText;
+      progressCell.appendChild(progressLabel);
+
+      tr.appendChild(progressCell);
+      tbody.appendChild(tr);
     });
     table.appendChild(tbody);
     container.appendChild(table);


### PR DESCRIPTION
## Summary
- add four-dimensional coverage heatmap data and normalized proportions to the coverage summary export
- append a coverage & representation table to the dataset card using the computed coverage summary
- enhance the QA dashboard coverage widget with quota-aware progress indicators and legend

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e533301b388328a19853070532dc29